### PR TITLE
feat: v1.3.0 - Redis Chaos Injection & Demo Encapsulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,17 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Release-v1.2.0-blue.svg" alt="Release">
+  <img src="https://img.shields.io/badge/Release-v1.3.0-blue.svg" alt="Release">
   <img src="https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go" alt="Go Version">
 </p>
 
----
 
 ## Features
 
-* **Application-Level Chaos:** Inject faults directly into HTTP middleware, SQL drivers, and **gRPC Interceptors (Unary & Stream)**.
+* **Application-Level Chaos:** Inject faults directly into HTTP middleware, SQL drivers, gRPC Interceptors, and **Redis Hooks**.
 * **Blast Radius Control (Targeted Chaos):** Apply chaos exclusively to specific users or segments by matching HTTP/gRPC headers.
 * **Hot-Reloading Configuration:** Update chaos policies on-the-fly via a `pastaay.yaml` file without restarting your application.
 * **Native Observability:** Built-in Prometheus metrics (`/metrics`) to track and graph injected faults.
-
 ---
 
 ## Installation
@@ -35,7 +33,7 @@ go get github.com/CemAkan/pastaay
 
 Pastaay uses a policy-based configuration. You can define multiple chaos rules and target specific endpoints or headers.
 
-**For a complete list of all supported types (`http`, `sql`, `grpc`) and parameters, please read the [Detailed Configuration Reference](docs/configuration.md).**
+**For a complete list of all supported types (`http`, `sql`, `grpc`,`redis`) and parameters, please read the [Detailed Configuration Reference](docs/configuration.md).**
 
 
 ```yaml
@@ -46,15 +44,11 @@ policies:
     type: "http"
     latency_chance: 1.0
     latency_duration: "2s"
-    error_chance: 0.0
 
-  - name: "break-grpc-stream"
-    target: "/service.v1.MyService/LiveChat"
-    type: "grpc"
-    latency_chance: 0.0
-    error_chance: 0.5
-    match_headers:
-      x-test-user: "true"
+  - name: "redis-cache-miss"
+    target: "get"
+    type: "redis"
+    error_chance: 0.5 # 50% chance to simulate a cache miss (returns redis.Nil)
 ```
 
 **2. Integrate into your Go application:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,15 +8,15 @@ The `pastaay.yaml` file is the heart of the chaos engine. It uses a policy-based
 
 Each policy in the `policies` list supports the following fields:
 
-| Field | Type | Required | Description |
-| :--- | :--- | :--- | :--- |
-| `name` | `string` | No | A unique identifier for the policy (useful for logging and debugging). |
-| `type` | `string` | **Yes** | The type of chaos target. Supported values: `http`, `sql`, `grpc`. |
-| `target` | `string` | **Yes** | The specific endpoint, database route, or gRPC method to target. |
-| `latency_chance` | `float` | No | Probability (0.0 to 1.0) of injecting latency. |
-| `latency_duration`| `string` | No | How long to delay the request (e.g., `500ms`, `2s`, `1.5s`). |
-| `error_chance` | `float` | No | Probability (0.0 to 1.0) of injecting a synthetic error/fault. |
-| `match_headers` | `map` | No | Key-value pairs for Blast Radius Control. |
+| Field | Type | Required | Description                                                               |
+| :--- | :--- | :--- |:--------------------------------------------------------------------------|
+| `name` | `string` | No | A unique identifier for the policy (useful for logging and debugging).    |
+| `type` | `string` | **Yes** | The type of chaos target. Supported values: `http`, `sql`, `grpc`,`redis`. |
+| `target` | `string` | **Yes** | The specific endpoint, database route, or gRPC method to target.          |
+| `latency_chance` | `float` | No | Probability (0.0 to 1.0) of injecting latency.                            |
+| `latency_duration`| `string` | No | How long to delay the request (e.g., `500ms`, `2s`, `1.5s`).              |
+| `error_chance` | `float` | No | Probability (0.0 to 1.0) of injecting a synthetic error/fault.            |
+| `match_headers` | `map` | No | Key-value pairs for Blast Radius Control.                                 |
 
 ---
 
@@ -34,6 +34,9 @@ Intercepts database queries at the driver level to simulate slow database connec
 Intercepts both Unary and Streaming gRPC calls to inject latency or `codes.Unavailable` errors.
 * **Target Format:** The Full Method Name (e.g., `/service.v1.MyService/MyMethod`).
 
+### 4. Redis Chaos (`type: "redis"`)
+Intercepts `go-redis/v9` commands to inject latency or simulate Cache Misses (`redis.Nil`). This is extremely useful for testing Cache Stampede scenarios.
+* **Target Format:** The specific Redis command to target (e.g., `"get"`, `"set"`), or use `"all"` to intercept every command.
 ---
 
 ## Blast Radius Control (`match_headers`)
@@ -84,6 +87,12 @@ policies:
     error_chance: 0.5
     match_headers:
       x-client-version: "v1.0.4"
+      
+  # 5. Intercept Redis GET commands and simulate Cache Misses 50% of the time
+  - name: "redis-stampede-test"
+    type: "redis"
+    target: "get"
+    error_chance: 0.5
 ```
 
 ## Hot-Reloading Behavior

--- a/examples/demo/Dockerfile
+++ b/examples/demo/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.23-alpine AS builder
 WORKDIR /app
+
 COPY . .
 RUN go mod download
 RUN go build -o pastaay-demo examples/demo/main.go
@@ -7,7 +8,7 @@ RUN go build -o pastaay-demo examples/demo/main.go
 FROM alpine:latest
 WORKDIR /root/
 COPY --from=builder /app/pastaay-demo .
-COPY --from=builder /app/pastaay.yaml .
+COPY --from=builder /app/examples/demo/pastaay.yaml .
 
 EXPOSE 8080 2112
 CMD ["./pastaay-demo"]

--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -7,15 +7,19 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/lib/pq"
+	"github.com/redis/go-redis/v9"
+
 	"github.com/CemAkan/pastaay/pkg/config"
 	"github.com/CemAkan/pastaay/pkg/metrics"
+	"github.com/CemAkan/pastaay/pkg/redischaos"
 	"github.com/CemAkan/pastaay/pkg/ritual"
 	"github.com/CemAkan/pastaay/pkg/sqlchaos"
-	"github.com/lib/pq"
 )
 
 type Response struct {
 	Message string `json:"message"`
+	Source  string `json:"source"`
 	Short   string `json:"short_url,omitempty"`
 }
 
@@ -25,7 +29,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to load initial config: %v", err)
 	}
-
 	cfgManager := config.NewManager(cfg)
 
 	// 2. Enable Hot Reloading
@@ -33,47 +36,61 @@ func main() {
 		cfgManager.Update(newCfg)
 		log.Println("Demo App: Pastaay configuration updated seamlessly!")
 	})
-	if err != nil {
-		log.Fatalf("Failed to start config watcher: %v", err)
-	}
 
 	// 3. Start Metrics Server
 	go metrics.StartServer(":2112")
 
-	// 4. Register and Connect to Database using Pastaay SQL Chaos Wrapper
-	sqlchaos.Register("pastaay-postgres", &pq.Driver{}, cfgManager)
+	// 4. Redis Client with Pastaay Chaos Hook
+	rdb := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379", // Use localhost for local dev, "redis:6379" if in Docker
+	})
+	rdb.AddHook(redischaos.NewChaosHook(cfgManager))
 
-	db, err := sql.Open("pastaay-postgres", "postgres://pastaay:secret@db:5432/shortener?sslmode=disable")
+	// 5. Database Setup with Pastaay SQL Chaos Wrapper
+	sqlchaos.Register("pastaay-postgres", &pq.Driver{}, cfgManager)
+	db, err := sql.Open("pastaay-postgres", "postgres://pastaay:secret@localhost:5432/shortener?sslmode=disable")
 	if err != nil {
 		log.Fatalf("Failed to open database connection: %v", err)
 	}
 	defer db.Close()
-
-	// Wait for DB to be ready and create a dummy table
 	time.Sleep(2 * time.Second)
 	_, _ = db.Exec("CREATE TABLE IF NOT EXISTS links (id SERIAL PRIMARY KEY, url TEXT)")
 
-	// 5. Setup Application Router
+	// 6. Setup Application Router
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/shorten", func(w http.ResponseWriter, r *http.Request) {
-		// Execute a database query targeted by chaos policies
-		_, dbErr := db.Exec("INSERT INTO links (url) VALUES ('http://short.ly/xyz123')")
-		if dbErr != nil {
-			log.Printf("DB Error: %v", dbErr)
+		ctx := r.Context()
+
+		// CHECK CACHE FIRST (Pastaay might intercept and simulate a Cache Miss)
+		val, err := rdb.Get(ctx, "latest_link").Result()
+
+		if err == redis.Nil {
+			log.Println("App: Cache Miss! Hitting database...")
+			// Write to database (Pastaay might inject latency here)
+			_, dbErr := db.Exec("INSERT INTO links (url) VALUES ('http://short.ly/xyz123')")
+			if dbErr != nil {
+				log.Printf("DB Error: %v", dbErr)
+			}
+			// Write back to cache
+			rdb.Set(ctx, "latest_link", "http://short.ly/xyz123", 1*time.Minute)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(Response{Message: "Saved and Cached!", Source: "Database", Short: "http://short.ly/xyz123"})
+			return
+		} else if err != nil {
+			log.Printf("Redis Error: %v", err)
 		}
 
+		// CACHE HIT (Returns quickly from here if Pastaay doesn't sabotage)
+		log.Println("App: Cache Hit!")
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(Response{
-			Message: "URL successfully shortened and saved to database!",
-			Short:   "http://short.ly/xyz123",
-		})
+		json.NewEncoder(w).Encode(Response{Message: "Retrieved from Cache!", Source: "Redis Cache", Short: val})
 	})
 
-	// 6. Wrap HTTP Handler with Pastaay HTTP Chaos Middleware
+	// 7. Wrap HTTP Handler with Pastaay HTTP Chaos Middleware
 	chaosHandler := ritual.Middleware(cfgManager)(mux)
 
-	log.Println("Demo App: URL Shortener running on :8080 with HTTP and SQL Chaos enabled")
+	log.Println("Demo App: Server running on :8080 with HTTP, SQL, and Redis Chaos enabled")
 	if err := http.ListenAndServe(":8080", chaosHandler); err != nil {
 		log.Fatalf("Server crashed: %v", err)
 	}

--- a/examples/demo/main_test.go
+++ b/examples/demo/main_test.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/CemAkan/pastaay/pkg/config"
-	"github.com/CemAkan/pastaay/pkg/sqlchaos"
-	"github.com/lib/pq"
 )
 
 // TestResponse_JSONSerialization verifies that our API response struct
@@ -26,53 +22,19 @@ func TestResponse_JSONSerialization(t *testing.T) {
 	}
 
 	jsonString := string(data)
-
 	if !strings.Contains(jsonString, `"message":"URL successfully shortened`) {
 		t.Errorf("Expected JSON to contain correct message, got: %s", jsonString)
 	}
 }
 
-// TestSQLChaos_RealDatabaseIntegration tests the actual injection of latency
-// into a live PostgreSQL database connection.
-func TestSQLChaos_RealDatabaseIntegration(t *testing.T) {
-	// 1. Force a guaranteed 200ms delay policy for database targets
-	cfg := &config.PastaayConfig{
-		Policies: []config.Policy{
-			{Target: "database", Type: "sql", LatencyChance: 1.0, LatencyDuration: 200 * time.Millisecond},
-		},
-	}
-	cfgManager := config.NewManager(cfg)
-
-	// 2. Register the real Postgres driver wrapped in our chaos agent
-	// We use a different name to avoid conflict with main.go during tests
-	sqlchaos.Register("pastaay-postgres-test", &pq.Driver{}, cfgManager)
-
-	// 3. Connect to the local Docker database
-	db, err := sql.Open("pastaay-postgres-test", "postgres://pastaay:secret@localhost:5433/shortener?sslmode=disable")
+// TestDemoConfigParsing verifies that the isolated demo config loads correctly.
+func TestDemoConfigParsing(t *testing.T) {
+	cfg, err := config.LoadConfig("pastaay.yaml")
 	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer db.Close()
-
-	// 4. Create a dummy table for the test
-	_, err = db.Exec("CREATE TABLE IF NOT EXISTS test_links (id SERIAL PRIMARY KEY, url TEXT)")
-	if err != nil {
-		t.Fatalf("Database not ready. Is docker-compose running? Error: %v", err)
+		t.Fatalf("Failed to load demo pastaay.yaml: %v", err)
 	}
 
-	// 5. Start the timer and execute the query
-	start := time.Now()
-	_, err = db.Exec("INSERT INTO test_links (url) VALUES ('http://test.ly')")
-	elapsed := time.Since(start)
-
-	if err != nil {
-		t.Fatalf("Insert query failed: %v", err)
-	}
-
-	// 6. Assert that the chaos wrapper actually delayed the query
-	if elapsed < 200*time.Millisecond {
-		t.Errorf("Expected query to take at least 200ms due to chaos injection, but it took only %v", elapsed)
-	} else {
-		t.Logf("Success! SQL Chaos delayed the query by %v", elapsed)
+	if len(cfg.Policies) == 0 {
+		t.Errorf("Expected policies in demo config, got 0")
 	}
 }

--- a/examples/demo/pastaay.yaml
+++ b/examples/demo/pastaay.yaml
@@ -1,0 +1,6 @@
+version: 1
+policies:
+  - name: "redis-cache-miss-attack"
+    type: "redis"
+    target: "get"
+    error_chance: 1.0  # 100% chance to simulate Cache Miss, forcing DB hit

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/lib/pq v1.12.3
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.18.0
 	google.golang.org/grpc v1.68.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -19,7 +20,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,14 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -15,6 +19,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -41,6 +47,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -33,10 +35,14 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/pastaay.yaml
+++ b/pastaay.yaml
@@ -1,16 +1,18 @@
 version: 1
 policies:
-  - name: "slow-down-http"
-    target: "/api/hello"
+  - name: "http-login-slowdown"
     type: "http"
-    latency_chance: 1.0
-    latency_duration: "2s"
-    error_chance: 0.0
+    target: "/api/v1/login"
+    latency_chance: 0.2
+    latency_duration: "1500ms"
 
-  - name: "break-grpc-stream"
-    target: "/service.v1.MyService/LiveChat"
-    type: "grpc"
-    latency_chance: 0.0
+  - name: "sql-global-degradation"
+    type: "sql"
+    target: "database"
+    latency_chance: 0.1
+    latency_duration: "3s"
+
+  - name: "redis-cache-miss-attack"
+    type: "redis"
+    target: "get"
     error_chance: 0.5
-    match_headers:
-      x-test-user: "true"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 
 // Policy defines the chaos injection rules and target criteria.
 type Policy struct {
+	Name            string            `yaml:"name"`
 	Target          string            `yaml:"target"`
 	Type            string            `yaml:"type"`
 	LatencyChance   float64           `yaml:"latency_chance"`

--- a/pkg/redischaos/hook.go
+++ b/pkg/redischaos/hook.go
@@ -1,0 +1,45 @@
+package redischaos
+
+import (
+	"context"
+	"net"
+
+	"github.com/CemAkan/pastaay/pkg/config"
+	"github.com/redis/go-redis/v9"
+)
+
+// ChaosHook implements redis.Hook to inject faults into Redis queries.
+type ChaosHook struct {
+	cfgManager *config.Manager
+}
+
+// NewChaosHook creates a new Redis hook driven by Pastaay policies.
+func NewChaosHook(cfgManager *config.Manager) *ChaosHook {
+	return &ChaosHook{
+		cfgManager: cfgManager,
+	}
+}
+
+// DialHook intercepts the connection dialer (required by redis.Hook interface).
+func (h *ChaosHook) DialHook(next redis.DialHook) redis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return next(ctx, network, addr)
+	}
+}
+
+// ProcessHook intercepts individual Redis commands (e.g., GET, SET).
+func (h *ChaosHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+
+		// TODO: Chaos logic will be implemented here
+
+		return next(ctx, cmd)
+	}
+}
+
+// ProcessPipelineHook intercepts Redis pipeline commands.
+func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		return next(ctx, cmds)
+	}
+}

--- a/pkg/redischaos/hook.go
+++ b/pkg/redischaos/hook.go
@@ -2,9 +2,13 @@ package redischaos
 
 import (
 	"context"
+	"log"
+	"math/rand"
 	"net"
+	"time"
 
 	"github.com/CemAkan/pastaay/pkg/config"
+	"github.com/CemAkan/pastaay/pkg/metrics"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -30,8 +34,34 @@ func (h *ChaosHook) DialHook(next redis.DialHook) redis.DialHook {
 // ProcessHook intercepts individual Redis commands (e.g., GET, SET).
 func (h *ChaosHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
+		currentConfig := h.cfgManager.Get()
+		var activePolicy *config.Policy
 
-		// TODO: Chaos logic will be implemented here
+		for _, policy := range currentConfig.Policies {
+			// Target can be a specific command like "get", "set", or "all"
+			if policy.Type == "redis" && (policy.Target == cmd.Name() || policy.Target == "all") {
+				p := policy
+				activePolicy = &p
+				break
+			}
+		}
+
+		if activePolicy != nil {
+			// Latency Injection
+			if activePolicy.LatencyChance > 0 && rand.Float64() < activePolicy.LatencyChance {
+				log.Printf("Pastaay Redis: Injecting %v latency to %s command", activePolicy.LatencyDuration, cmd.Name())
+				metrics.InjectedFaultsTotal.WithLabelValues("redis_"+cmd.Name(), "latency").Inc()
+				time.Sleep(activePolicy.LatencyDuration)
+			}
+
+			// Error (Cache Miss) Injection
+			if activePolicy.ErrorChance > 0 && rand.Float64() < activePolicy.ErrorChance {
+				log.Printf("Pastaay Redis: Simulating Cache Miss (redis.Nil) for %s command", cmd.Name())
+				metrics.InjectedFaultsTotal.WithLabelValues("redis_"+cmd.Name(), "error").Inc()
+				// Simulate "no data" to force a database hit (Cache Stampede simulation)
+				return redis.Nil
+			}
+		}
 
 		return next(ctx, cmd)
 	}

--- a/pkg/redischaos/hook_test.go
+++ b/pkg/redischaos/hook_test.go
@@ -1,1 +1,76 @@
 package redischaos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CemAkan/pastaay/pkg/config"
+	"github.com/redis/go-redis/v9"
+)
+
+// mockCmder implements a simple redis.Cmder for testing
+type mockCmder struct {
+	redis.Cmder
+	name string
+}
+
+func (m *mockCmder) Name() string {
+	return m.name
+}
+
+func TestRedisHook_ErrorInjection(t *testing.T) {
+	// inject error for get commands
+	cfgManager := config.NewManager(&config.PastaayConfig{
+		Policies: []config.Policy{
+			{
+				Name:        "test-redis-error",
+				Type:        "redis",
+				Target:      "get",
+				ErrorChance: 1.0, // %100 Cache Miss
+			},
+		},
+	})
+
+	hook := NewChaosHook(cfgManager)
+
+	nextCalled := false
+	next := func(ctx context.Context, cmd redis.Cmder) error {
+		nextCalled = true
+		return nil
+	}
+
+	processHook := hook.ProcessHook(next)
+
+	cmd := &mockCmder{name: "get"}
+	err := processHook(context.Background(), cmd)
+
+	if err != redis.Nil {
+		t.Errorf("Expected redis.Nil error, got %v", err)
+	}
+	if nextCalled {
+		t.Errorf("Expected next handler NOT to be called when error is injected")
+	}
+}
+
+func TestRedisHook_Bypass(t *testing.T) {
+	// empty conf, no chaos
+	cfgManager := config.NewManager(&config.PastaayConfig{})
+	hook := NewChaosHook(cfgManager)
+
+	nextCalled := false
+	next := func(ctx context.Context, cmd redis.Cmder) error {
+		nextCalled = true
+		return nil
+	}
+
+	processHook := hook.ProcessHook(next)
+	cmd := &mockCmder{name: "get"}
+	err := processHook(context.Background(), cmd)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if !nextCalled {
+		t.Errorf("Expected next handler to be called")
+	}
+}

--- a/pkg/redischaos/hook_test.go
+++ b/pkg/redischaos/hook_test.go
@@ -1,0 +1,1 @@
+package redischaos


### PR DESCRIPTION
This PR introduces Redis chaos injection via a custom `go-redis/v9` hook, allowing users to simulate cache misses (`redis.Nil`) and test database fallback behaviors.

Changes included:
- Added Redis chaos hook for latency and error injection.
- Refactored `examples/demo` into a completely standalone environment with its own `pastaay.yaml` and `Dockerfile`.
- Removed database-dependent tests from the demo to prevent CI pipeline flakes.
- Fixed the missing `Name` field in the `Policy` struct.
