### PR TITLE
fix: security hardening, tie-break guards, mongo client, config improvements (v2.3.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ go.work.sum
 
 .DS_Store
 **/.DS_Store
+cmd/pastaayctl/pastaayctl

--- a/README.md
+++ b/README.md
@@ -15,50 +15,50 @@
 **The Chaos Engine**
 * **Universal Interceptors:** Native fault injection for Kafka, RabbitMQ, HTTP, gRPC, SQL, MongoDB, and Redis.
 * **Resource Sabotage:** Simulate CPU starvation and memory leaks with guaranteed cleanup via the Amnesia Protocol.
-* **Security Hardened:** Constant-time token verification, memory-bounded payload processing (`io.LimitReader`), and native evasion protection.
-* **Deterministic Cascading:** Complex gRPC stream rules with stable session hashing that do not short-circuit.
+* **Security Hardened:** Constant time token verification, memory bounded payload processing (`io.LimitReader`), and native evasion protection.
+* **Deterministic Cascading:** Complex gRPC stream rules with stable session hashing that do not short circuit.
 
 **Control & Observability**
-* **AI SRE Copilot (Oracle):** Native multi-LLM integration (Gemini, Claude, GPT) that autonomously analyzes live telemetry to generate and inject optimal chaos configurations.
-* **Kinetic Control Plane:** Fleet-wide orchestration via the **`pastaayctl`** CLI, featuring imperative strikes, SLA-guarded autopilot, and real-time telemetry dashboards.
-* **Distributed Tracing:** Zero-allocation OpenTelemetry (OTLP) integration for visualizing chaos events across microservices without goroutine leaks.
-* **Self-Aware Sensors:** Real-time health monitoring and asynchronous telemetry for remote control providers.
-* **Web Console:** Centralized dashboard with real-time telemetry grid, drag-and-drop policy builder, and the **Resilience Probe** — an Apdex-based system resilience monitor with server-side proxy probing and diagnostic field popovers.
+* **AI SRE Copilot (Oracle):** Native multi LLM integration (Gemini, Claude, GPT) that autonomously analyzes live telemetry to generate and inject optimal chaos configurations.
+* **Kinetic Control Plane:** Fleet wide orchestration via the **`pastaayctl`** CLI, featuring imperative strikes, SLA guarded autopilot, and real time telemetry dashboards.
+* **Distributed Tracing:** Zero allocation OpenTelemetry (OTLP) integration for visualizing chaos events across microservices without goroutine leaks.
+* **Self aware Sensors:** Real time health monitoring and asynchronous telemetry for remote control providers.
+* **Web Console:** Centralized dashboard with real time telemetry grid, drag and drop policy builder, and the **Resilience Probe**, an Apdex based system resilience monitor with server side proxy probing and diagnostic field popovers.
 
-**Cloud-Native & GitOps**
+**Cloud native & GitOps**
 * **Kubernetes Native:** Seamlessly manage chaos via Custom Resource Definitions (`ChaosPolicy`) powered by the Pastaay Operator.
 * **GitOps Ready:** Full reference architectures for ArgoCD and Flux with autonomous rollbacks powered by the new `duration` spec.
-* **CI/CD Integration:** Native GitHub Action (`pastaay-strike`) to execute SLA-guarded chaos experiments directly in your pipelines.
+* **CI/CD Integration:** Native GitHub Action (`pastaay-strike`) to execute SLA guarded chaos experiments directly in your pipelines.
 ---
 
-## Hot-Reloading & Reactivity
+## Hot reloading & Reactivity
 
-Pastaay is built to be reactive. The engine monitors configuration states via an **amnesia-proof filesystem watcher** and remote telemetry channels. It instantly transitions between stable, high-latency (Glitch), and disconnected (Void) states without dropping underlying connections or requiring service restarts.
+Pastaay is built to be reactive. The engine monitors configuration states via an **amnesia proof filesystem watcher** and remote telemetry channels. It instantly transitions between stable, high latency (Glitch), and disconnected (Void) states without dropping underlying connections or requiring service restarts.
 
 <p align="center">
-  <img src="docs/assets/hot_reload_demo.gif" width="850" alt="Pastaay Hot-Reloading Demonstration">
+  <img src="docs/assets/hot_reload_demo.gif" width="850" alt="Pastaay Hot reloading Demonstration">
 </p>
 
 ---
 
 ## Distributed Tracing (OpenTelemetry)
 
-Pastaay features zero-allocation distributed tracing out-of-the-box. It automatically injects high-fidelity spans into your active context during a chaos event, providing granular visibility into exactly *where*, *when*, and *how* your system was disrupted.
+Pastaay features zero allocation distributed tracing out-of-the-box. It automatically injects high-fidelity spans into your active context during a chaos event, providing granular visibility into exactly *where*, *when*, and *how* your system was disrupted.
 
 To enable tracing, configure the following environment variable on your host application:
 
 | Environment Variable | Description | Example |
 | :--- | :--- | :--- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | The gRPC endpoint of your OTel Collector. If left empty, tracing safely defaults to a zero-overhead `No-Op` mode. | `http://otel-collector:4317` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | The gRPC endpoint of your OTel Collector. If left empty, tracing safely defaults to a zero overhead `No-Op` mode. | `http://otel-collector:4317` |
 
-### The Zero-Overhead Guarantee
+### The Zero overhead Guarantee
 Pastaay utilizes OpenTelemetry's `BatchSpanProcessor`. This means chaos spans are flushed asynchronously. Even if your tracing backend (like Jaeger or Zipkin) goes offline, experiences severe latency, or is overwhelmed by trace volume, Pastaay will **never block your application's critical path** or leak goroutines.
 
 ---
 
 ## Zero Allocation
 
-Pastaay is built to survive high-throughput data streams. Our core evaluator guarantees **O(1)** policy lookups and **0 Bytes** of memory allocation per operation, ensuring your application never suffers from Garbage Collection (GC) spikes.
+Pastaay is built to survive high throughput data streams. Our core evaluator guarantees **O(1)** policy lookups and **0 Bytes** of memory allocation per operation, ensuring your application never suffers from Garbage Collection (GC) spikes.
 
 <p align="center">
   <img src="docs/assets/benchmark.png" alt="Pastaay Zero Allocation Benchmark">
@@ -72,40 +72,40 @@ Pastaay is built to survive high-throughput data streams. Our core evaluator gua
   <img src="docs/assets/milkshake4drBishop.gif" alt="FRINGE <3">
 </p>
 
-Pastaay is a continuously evolving enterprise chaos engineering suite. Our development phases are strictly focused on cloud-native scalability and GitOps integrations.
+Pastaay is a continuously evolving enterprise chaos engineering suite. Our development phases are strictly focused on cloud native scalability and GitOps integrations.
 
 | Phase              | Theme | Architecture Goals |
 |:-------------------| :--- | :--- |
 | **Current (v2.3)** | **Web Console** | Centralized web dashboard for direct fleet management, visual impact analysis, and interactive documentation. |
-| **Next**           | **CEL-Driven Rule Engine** | **Dynamic Evaluation:** Integrating Google's Common Expression Language (CEL) to allow complex, AST-compiled conditional chaos rules (e.g., payload limits, header regex) with zero-allocation overhead. |
-| **Future**         | **Trace-Aware Injection** | **Context-Propagated Chaos:** Leveraging OpenTelemetry Baggage to inject faults based on the complete distributed request journey, targeting specific end-to-end transaction flows across the fleet. |
+| **Next**           | **CEL driven Rule Engine** | **Dynamic Evaluation:** Integrating Google's Common Expression Language (CEL) to allow complex, AST-compiled conditional chaos rules (e.g., payload limits, header regex) with zero allocation overhead. |
+| **Future**         | **Trace aware Injection** | **context propagated Chaos:** Leveraging OpenTelemetry Baggage to inject faults based on the complete distributed request journey, targeting specific end-to-end transaction flows across the fleet. |
 
 ## Web Console
 
-Pastaay v2.3 introduces a fully client-side **Web Console**, a real-time observability hub served directly from the engine's embedded filesystem at `http://localhost:2112/console`. No external dependencies, no Node.js, no React.
+Pastaay v2.3 introduces a fully client side **Web Console**, a real time observability hub served directly from the engine's embedded filesystem at `http://localhost:2112/console`. No external dependencies, no Node.js, no React.
 
 <p align="center">
   <img src="docs/assets/web_console_demo.gif" width="850" alt="Pastaay Web Console Demo">
 </p>
 
-**Telemetry Panels**, A modular, drag-and-drop grid with persistent layout:
+**Telemetry Panels**, A modular, drag and drop grid with persistent layout:
 
-* **Global Fault Velocity:** Real-time line chart of total fault injection rate (req/s). Powered by ECharts, reading `pastaay_injected_faults_total` directly from the engine's Prometheus gatherer.
-* **Blast Radius Matrix:** Stacked bar chart correlating errors, latency spikes, and dropped connections across the top 5 most-targeted services.
-* **System Output Journal:** Lock-free circular log viewer with hierarchical filtering (Pod → Protocol → Method), text search, live/pause toggle, and click-to-decrypt payload tracing. Streams Kubernetes pod logs via the Watch API.
-* **Resilience Probe:** Apdex-based health monitor probing target URLs through a **server-side proxy** (`POST /console/api/probe`) to bypass CORS. Features multi-target round-robin, EMA-smoothed scoring, adjustable thresholds, and clickable diagnostic popovers.
+* **Global Fault Velocity:** Real time line chart of total fault injection rate (req/s). Powered by ECharts, reading `pastaay_injected_faults_total` directly from the engine's Prometheus gatherer.
+* **Blast Radius Matrix:** Stacked bar chart correlating errors, latency spikes, and dropped connections across the top 5 most targeted services.
+* **System Output Journal:** Lock free circular log viewer with hierarchical filtering (Pod → Protocol → Method), text search, live/pause toggle, and click to decrypt payload tracing. Streams Kubernetes pod logs via the Watch API.
+* **Resilience Probe:** Apdex based health monitor probing target URLs through a **server side proxy** (`POST /console/api/probe`) to bypass CORS. Features multi target round robin, EMA smoothed scoring, adjustable thresholds, and clickable diagnostic popovers.
 
 **Key Capabilities:**
-* **Sortable & Persistent:** Drag-and-drop reordering saved to `localStorage`.
+* **Sortable & Persistent:** Drag and drop reordering saved to `localStorage`.
 * **Expand/Collapse:** Each panel expands to show detailed diagnostics and tuning controls.
 * **Engine Status Bar:** Live sensor fabric, active policy count, and emergency `HALT EXPERIMENTS`.
 * **Dark/Light Theme:** Toggle persisted across sessions.
 
 **Additional Views:**
 
-* **Builder**: Visual policy configurator with type-specific sabotage fields (gRPC stream modes, RAM chunks, CPU throttles). Generates YAML payloads validated by a blast radius guard.
+* **Builder**: Visual policy configurator with type specific sabotage fields (gRPC stream modes, RAM chunks, CPU throttles). Generates YAML payloads validated by a blast radius guard.
 * **Oracle**: AI SRE Copilot: paste infrastructure context and let LLMs autonomously generate optimal chaos configurations.
-* **Docs**: Interactive documentation with full-text search, navigation tree, and API reference.
+* **Docs**: Interactive documentation with full text search, navigation tree, and API reference.
 
 > **Full architecture, API reference & diagnostic field docs:** [docs/web_console.md](docs/web_console.md)
 
@@ -115,9 +115,9 @@ Pastaay v2.3 introduces a fully client-side **Web Console**, a real-time observa
 
 Dive deep into Pastaay's mechanics using our official documentation:
 * [The Configuration Guide](docs/configuration.md) - Learn how to write policies, target endpoints, and control the blast radius.
-* [Architecture & Engine](docs/architecture.md) - Understand how the Policy Engine achieves zero-latency lookups, and how we solved deep OS/Compiler integration constraints.
-* [Remote Control & Cloud-Native Sensors](docs/remote_control.md) - Learn how to securely control chaos across massive fleets via Redis, Kubernetes, or Webhooks.
-* [pastaayctl: Kinetic Control Plane Reference](docs/pastaayctl.md) - Master the CLI to orchestrate fleet-wide chaos, run SLA-guarded autopilot experiments, and monitor real-time kinetic impact.
+* [Architecture & Engine](docs/architecture.md) - Understand how the Policy Engine achieves zero latency lookups, and how we solved deep OS/Compiler integration constraints.
+* [Remote Control & Cloud native Sensors](docs/remote_control.md) - Learn how to securely control chaos across massive fleets via Redis, Kubernetes, or Webhooks.
+* [pastaayctl: Kinetic Control Plane Reference](docs/pastaayctl.md) - Master the CLI to orchestrate fleet wide chaos, run SLA guarded autopilot experiments, and monitor real time kinetic impact.
 * [Pastaay Kubernetes Operator](docs/operator.md) - Learn how to deploy the operator and manage chaos natively using Kubernetes CRDs.
 * [GitOps & CI/CD Integrations](examples/gitops/README.md) - Reference architectures for declarative chaos management via ArgoCD and pipeline automation.
 * [Web Console](docs/web_console.md) - Explore the centralized dashboard for fleet management and impact visualization.
@@ -168,7 +168,7 @@ import (
 )
 
 func main() {
-   // Load config & enable amnesia-proof hot-reload
+   // Load config & enable amnesia proof hot reload
    cfg, _ := config.LoadConfig("pastaay.yaml")
    cfgManager := config.NewManager(cfg)
    config.WatchConfig("pastaay.yaml", cfgManager.Update)
@@ -202,7 +202,7 @@ make -C operator deploy IMG=<your-registry>/pastaay-operator:v2.3.0
 
 ## Running the Demos
 
-Pastaay ships with two distinct examples to help you understand both its integration mechanics and its real-time reactivity.
+Pastaay ships with two distinct examples to help you understand both its integration mechanics and its real time reactivity.
 1. The Integration Demo
    A complete, hardened microservice stack (URL Shortener API, PostgreSQL, Redis, MongoDB, Kafka, RabbitMQ) showing how to securely integrate Pastaay without race conditions.
 
@@ -220,7 +220,7 @@ docker compose logs -f app
 <br>
 
 2. The TUI Visualizer (Vortex)
-   A standalone terminal user interface built to demonstrate Pastaay's amnesia-proof hot-reloading. This is the source of the GIF shown above.
+   A standalone terminal user interface built to demonstrate Pastaay's amnesia proof hot reloading. This is the source of the GIF shown above.
    cd examples/visualizer
 
 ```bash
@@ -242,7 +242,7 @@ Please read the [Contributing Guide](CONTRIBUTING.md) for detailed instructions 
 
 ##  License
 
-Pastaay is open-sourced software licensed under the [MIT License](LICENSE).
+Pastaay is open source software licensed under the [MIT License](LICENSE).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ Please read the [Contributing Guide](CONTRIBUTING.md) for detailed instructions 
 
 Pastaay is open source software licensed under the [MIT License](LICENSE).
 
+---
+
+## Read the Deep Dive
+
+[I Built a Chaos Engine That Goes Where No Tool Has Gone Before](https://medium.com/@cemakan/i-built-a-chaos-engineering-engine-that-goes-where-no-tool-has-gone-before-65d88fb141f3)
+
+16 sections covering every interceptor, the watcher, the guard, the Oracle prompt engineering, and the production bugs I hit along the way.
+
+---
+
 <br>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Release-v2.3.0-stable.svg" alt="Release">
+  <img src="https://img.shields.io/badge/Release-v2.3.1-stable.svg" alt="Release">
   <img src="https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go" alt="Go Version">
   <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License">
 </p>
@@ -195,7 +195,7 @@ func main() {
 make -C operator install
 
 # Deploy the operator to your cluster
-make -C operator deploy IMG=<your-registry>/pastaay-operator:v2.3.0
+make -C operator deploy IMG=<your-registry>/pastaay-operator:v2.3.1
 ```
 
 ---

--- a/cmd/pastaayctl/cmd/attack.go
+++ b/cmd/pastaayctl/cmd/attack.go
@@ -214,10 +214,16 @@ func executeHTTPInjection(payload []byte) {
 func executeRedisBroadcast(payload []byte) {
 	addr := os.Getenv("PASTAAY_REDIS_ADDR")
 	if addr == "" {
-		addr = "localhost:6380"
+		fmt.Printf("%s[!] PASTAAY_REDIS_ADDR is not set — refusing to publish chaos policies to an implicit address.%s\n", cRed, cReset)
+		fmt.Printf("    %s(set PASTAAY_REDIS_ADDR explicitly; for local dev export PASTAAY_REDIS_ADDR=localhost:6379)%s\n", cGray, cReset)
+		return
 	}
 
-	rdb := redis.NewClient(&redis.Options{Addr: addr})
+	opts := &redis.Options{Addr: addr}
+	if pw := os.Getenv("PASTAAY_REDIS_PASSWORD"); pw != "" {
+		opts.Password = pw
+	}
+	rdb := redis.NewClient(opts)
 	defer rdb.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/pastaayctl/cmd/oracle.go
+++ b/cmd/pastaayctl/cmd/oracle.go
@@ -33,7 +33,7 @@ var oracleCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(oracleCmd)
 	oracleCmd.Flags().StringVar(&aiProvider, "provider", "openai", "AI Provider (openai, deepseek, gemini, anthropic)")
-	oracleCmd.Flags().StringVar(&aiKey, "api-key", "", "API Key for the provider (falls back to PASTAAY_AI_KEY env var)")
+	oracleCmd.Flags().StringVar(&aiKey, "api-key", "", "API Key (DEPRECATED — use PASTAAY_AI_KEY env var. Refused unless PASTAAY_ALLOW_CLI_KEY=1)")
 	oracleCmd.Flags().StringVar(&oracleHealthURL, "health-url", "", "Custom health check URL for baseline latency calculation")
 	oracleCmd.Flags().StringVarP(&aiModel, "model", "m", "", "Specific AI model to use (falls back to provider default)")
 	oracleCmd.Flags().StringVar(&aiIntensity, "intensity", "high", "Chaos intensity level: low, medium, high, nuke")
@@ -52,17 +52,22 @@ func runOracle(cmd *cobra.Command, args []string) {
 	fmt.Printf("  %s[*] \"We're pushing the boundaries of all that is real and possible.\"%s\n", clrGray, clrReset)
 
 	apiKey := aiKey
-	if apiKey == "" {
+	if apiKey != "" {
+		if os.Getenv("PASTAAY_ALLOW_CLI_KEY") != "1" {
+			fmt.Printf("\n%s[!] Refusing --api-key (visible in `ps aux`). Set PASTAAY_AI_KEY env var, or PASTAAY_ALLOW_CLI_KEY=1 to override.%s\n", clrRed, clrReset)
+			os.Exit(1)
+		}
+		fmt.Printf("  %s[!] WARNING: API key via --api-key is visible in `ps aux`.%s\n", clrYellow, clrReset)
+	} else {
 		apiKey = os.Getenv("PASTAAY_AI_KEY")
 	}
 	if apiKey == "" {
-		fmt.Printf("\n%s[!] Authentication Failed: No API key provided.%s\n", clrRed, clrReset)
+		fmt.Printf("\n%s[!] Authentication Failed: No API key provided (set PASTAAY_AI_KEY).%s\n", clrRed, clrReset)
 		os.Exit(1)
 	}
 
 	userPrompt := strings.Join(args, " ")
 
-	// Bounded context
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -88,7 +93,7 @@ func runOracle(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	response, err := oracle.AskOracle(provider, apiKey, modelToUse, aiIntensity, userPrompt, sysContext)
+	response, err := oracle.AskOracleCtx(ctx, provider, apiKey, modelToUse, aiIntensity, userPrompt, sysContext)
 	if err != nil {
 		fmt.Printf("\n%s[!] Oracle Link Severed: %v%s\n", clrRed, err, clrReset)
 		os.Exit(1)
@@ -119,7 +124,6 @@ func runOracle(cmd *cobra.Command, args []string) {
 	}
 }
 
-// gatherSystemContext fetches the live active-policy YAML from the engine /chaos/export endpoint.
 func gatherSystemContext(ctx context.Context) string {
 	var sb strings.Builder
 	sb.WriteString("ACTIVE POLICIES (YAML):\n")

--- a/cmd/pastaayctl/cmd/root.go
+++ b/cmd/pastaayctl/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -111,7 +112,7 @@ func setupEnvironment() {
 	cf, err := loadConfigFile(configPath)
 
 	if err != nil {
-		fmt.Println("ERROR: Conf file can not load")
+		fmt.Fprintf(os.Stderr, "ERROR: cannot load profile registry (%s): %v\n", configPath, err); os.Exit(1)
 	}
 
 	active := cf.CurrentContext

--- a/cmd/pastaayctl/cmd/root.go
+++ b/cmd/pastaayctl/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -49,7 +51,10 @@ var rootCmd = &cobra.Command{
 
 func Execute() error {
 	buildCustomHelpTemplate()
-	return rootCmd.Execute()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return rootCmd.ExecuteContext(ctx)
 }
 
 func init() {
@@ -112,7 +117,8 @@ func setupEnvironment() {
 	cf, err := loadConfigFile(configPath)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: cannot load profile registry (%s): %v\n", configPath, err); os.Exit(1)
+		fmt.Fprintf(os.Stderr, "ERROR: cannot load profile registry (%s): %v\n", configPath, err)
+		os.Exit(1)
 	}
 
 	active := cf.CurrentContext

--- a/cmd/pastaayctl/cmd/telemetry.go
+++ b/cmd/pastaayctl/cmd/telemetry.go
@@ -36,27 +36,31 @@ func init() {
 	rootCmd.AddCommand(topCmd, statusCmd, discoverCmd, inspectCmd)
 }
 
-// Logic Implementations
+// signalContext returns a context that cancels on SIGINT/SIGTERM.
+func signalContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}
+
 func runTop(cmd *cobra.Command, args []string) {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := signalContext()
 	defer stop()
 
 	if outputJSON {
 		resp, err := fetchMetrics(ctx)
 		if err != nil {
-			json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
 			return
 		}
 		defer resp.Body.Close()
-		json.NewEncoder(os.Stdout).Encode(map[string]string{"status": "metric_stream_active", "info": "use /metrics directly for json dump"})
+		_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"status": "metric_stream_active", "info": "use /metrics directly for json dump"})
 		return
 	}
 
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	fmt.Print("\033[?25l")       // Hide cursor
-	defer fmt.Print("\033[?25h") // Show cursor
+	fmt.Print("\033[?25l")
+	defer fmt.Print("\033[?25h")
 
 	lastFaults := make(map[string]int)
 
@@ -82,10 +86,13 @@ func runTop(cmd *cobra.Command, args []string) {
 }
 
 func runStatus(cmd *cobra.Command, args []string) {
-	resp, err := fetchMetrics(context.Background())
+	ctx, stop := signalContext()
+	defer stop()
+
+	resp, err := fetchMetrics(ctx)
 	if err != nil {
 		if outputJSON {
-			json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
 		} else {
 			fmt.Printf("%s[!] Failed to reach fleet: %v%s\n", cRed, err, cReset)
 		}
@@ -116,7 +123,7 @@ func runStatus(cmd *cobra.Command, args []string) {
 	}
 
 	if outputJSON {
-		json.NewEncoder(os.Stdout).Encode(data)
+		_ = json.NewEncoder(os.Stdout).Encode(data)
 		return
 	}
 
@@ -129,14 +136,17 @@ func runStatus(cmd *cobra.Command, args []string) {
 		}
 		fmt.Fprintf(w, "[%s]\t%s%s%s\t%s\n", cCyan+strings.ToUpper(d.Name)+cReset, color, d.Status, cReset, d.Endpoint)
 	}
-	w.Flush()
+	_ = w.Flush()
 }
 
 func runDiscover(cmd *cobra.Command, args []string) {
-	resp, err := fetchMetrics(context.Background())
+	ctx, stop := signalContext()
+	defer stop()
+
+	resp, err := fetchMetrics(ctx)
 	if err != nil {
 		if outputJSON {
-			json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
 		} else {
 			fmt.Printf("%s[!] Topology Discovery Failed: %v%s\n", cRed, err, cReset)
 		}
@@ -165,7 +175,7 @@ func runDiscover(cmd *cobra.Command, args []string) {
 	}
 
 	if outputJSON {
-		json.NewEncoder(os.Stdout).Encode(map[string]interface{}{"topology": targetList})
+		_ = json.NewEncoder(os.Stdout).Encode(map[string]interface{}{"topology": targetList})
 		return
 	}
 
@@ -177,13 +187,23 @@ func runDiscover(cmd *cobra.Command, args []string) {
 }
 
 func runInspect(cmd *cobra.Command, args []string) {
-	url := strings.TrimSuffix(targetURL, "/metrics") + "/chaos/export"
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-	resp, err := telemetryClient.Do(req)
+	ctx, stop := signalContext()
+	defer stop()
 
+	url := strings.TrimSuffix(targetURL, "/metrics") + "/chaos/export"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		if outputJSON {
-			json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+		} else {
+			fmt.Printf("%s[!] Bad target URL: %v%s\n", cRed, err, cReset)
+		}
+		return
+	}
+	resp, err := telemetryClient.Do(req)
+	if err != nil {
+		if outputJSON {
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
 		} else {
 			fmt.Printf("%s[!] Target Unreachable: %v%s\n", cRed, err, cReset)
 		}
@@ -193,14 +213,22 @@ func runInspect(cmd *cobra.Command, args []string) {
 
 	if resp.StatusCode != http.StatusOK {
 		if outputJSON {
-			json.NewEncoder(os.Stdout).Encode(map[string]string{"error": fmt.Sprintf("Server returned %d", resp.StatusCode)})
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": fmt.Sprintf("Server returned %d", resp.StatusCode)})
 		} else {
 			fmt.Printf("%s[!] Inspect Failed: Server returned HTTP %d%s\n", cRed, resp.StatusCode, cReset)
 		}
 		return
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if outputJSON {
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+		} else {
+			fmt.Printf("%s[!] Read failed: %v%s\n", cRed, err, cReset)
+		}
+		return
+	}
 	if outputJSON {
 		fmt.Printf("%s\n", string(body))
 		return
@@ -208,7 +236,6 @@ func runInspect(cmd *cobra.Command, args []string) {
 	fmt.Printf("\n%s═══ ENGINE MEMORY X-RAY ═══%s\n%s%s%s\n", cBold+cGreen, cReset, cGray, string(body), cReset)
 }
 
-// Helpers
 func fetchMetrics(ctx context.Context) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
@@ -218,12 +245,12 @@ func fetchMetrics(ctx context.Context) (*http.Response, error) {
 }
 
 func drawOfflineScreen(msg string) {
-	fmt.Print("\033[H\033[2J") // Clear Screen
+	fmt.Print("\033[H\033[2J")
 	fmt.Printf("%s[!] FLEET CONNECTION SEVERED%s\nError: %s\n", cBold+cRed, cReset, msg)
 }
 
 func renderDashboard(resp *http.Response, lastFaults map[string]int) {
-	fmt.Print("\033[H\033[2J") // Clear Screen
+	fmt.Print("\033[H\033[2J")
 	fmt.Printf("%sPASTAAY%s KINETIC CONTROL PLANE %sv2.0-stable%s\n", cBold+cCyan, cReset, cGray, cReset)
 	fmt.Println(strings.Repeat("─", 85))
 	fmt.Printf("%-35s | %-15s | %-12s | %-10s\n", "TARGET (Endpoint/Query)", "FAULT TYPE", "TOTAL HITS", "RATE (req/s)")

--- a/cmd/pastaayctl/cmd/utility.go
+++ b/cmd/pastaayctl/cmd/utility.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,22 +39,30 @@ func init() {
 
 func runGenerate(cmd *cobra.Command, args []string) {
 	templates := map[string]string{
-		"db-outage": "version: 1\npolicies:\n  - name: db-kill\n    type: sql\n    target: all\n    drop_connection: true",
-		"meltdown":  "version: 1\npolicies:\n  - name: resource-leak\n    type: resource\n    target: host\n    ram_chunk_mb: 256\n    ram_interval: 1s",
+		"db-outage":      "version: 1\npolicies:\n  - name: db-kill\n    type: sql\n    target: all\n    drop_connection: true\n    error_chance: 1.0",
+		"meltdown":       "version: 1\npolicies:\n  - name: resource-leak\n    type: resource\n    target: host\n    ram_chunk_mb: 256\n    ram_interval: 1s\n    latency_duration: 60s",
+		"cache-stampede": "version: 1\npolicies:\n  - name: redis-stampede\n    type: redis\n    target: GET\n    latency_chance: 0.8\n    latency_duration: 2s\n    error_chance: 0.2\n    error_code: 500",
 	}
 
 	if val, ok := templates[strings.ToLower(args[0])]; ok {
 		fmt.Println(val)
 	} else {
-		fmt.Printf("Unknown scenario. Available: db-outage, meltdown\n")
+		fmt.Printf("Unknown scenario. Available: db-outage, meltdown, cache-stampede\n")
 	}
 }
 
 func runExport(cmd *cobra.Command, args []string) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	url := strings.TrimSuffix(targetURL, "/metrics") + "/chaos/export"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Printf("\033[31m[!] Export Failed: Bad target URL (%v)\033[0m\n", err)
+		return
+	}
 	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(url)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		fmt.Printf("\033[31m[!] Export Failed: Target Unreachable (%v)\033[0m\n", err)
@@ -63,6 +75,10 @@ func runExport(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("\033[31m[!] Export Failed: response read (%v)\033[0m\n", err)
+		return
+	}
 	fmt.Printf("%s\n", string(body))
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ graph LR
     class CTL,OP,WC control;
 ```
 ---
-The Web Console and Resilience Probe architecture is documented in detail at **[docs/web_console.md](web_console.md)** — including Mermaid diagrams for the probe proxy flow, API endpoint reference, and diagnostic field documentation.
+The Web Console and Resilience Probe architecture is documented in detail at **[docs/web_console.md](web_console.md)**, including Mermaid diagrams for the probe proxy flow, API endpoint reference, and diagnostic field documentation.
 
 ---
 

--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -99,9 +99,17 @@ func main() {
 	web.RegisterHandlers(adminMux, cfgManager)
 
 	adminAddr := getEnv("ADMIN_ADDR", ":2112")
+	adminSrv := &http.Server{
+		Addr:              adminAddr,
+		Handler:           adminMux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 	go func() {
 		log.Printf("[INFO] Pastaay Admin Server listening on %s", adminAddr)
-		if err := http.ListenAndServe(adminAddr, adminMux); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := adminSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("[ERROR] Admin server crashed: %v", err)
 			stop()
 		}
@@ -169,10 +177,12 @@ func main() {
 	chaosHandler := ritual.Middleware(cfgManager)(mux)
 
 	srv := &http.Server{
-		Addr:         appAddr,
-		Handler:      chaosHandler,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:              appAddr,
+		Handler:           chaosHandler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	// Graceful Shutdown Orchestration
@@ -186,6 +196,9 @@ func main() {
 
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			log.Printf("[WARN] HTTP server shutdown: %v", err)
+		}
+		if err := adminSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("[WARN] Admin server shutdown: %v", err)
 		}
 
 		wg.Wait()

--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -80,8 +80,11 @@ func main() {
 		log.Fatalf("[FATAL] Core configuration load failure: %v", err)
 	}
 	cfgManager := config.NewManager(cfg)
-	if err := config.WatchConfig(cfgPath, cfgManager.Update); err != nil {
-		log.Printf("[WARN] config hot-reload watcher disabled: %v", err)
+	stopWatcher, werr := config.WatchConfig(cfgPath, cfgManager.Update)
+	if werr != nil {
+		log.Printf("[WARN] config hot-reload watcher disabled: %v", werr)
+	} else {
+		defer stopWatcher()
 	}
 
 	// Admin Server
@@ -96,7 +99,7 @@ func main() {
 	adminMux.HandleFunc("/chaos/webhook", config.WebhookHandler(webhookToken, cfgManager.Update))
 	adminMux.HandleFunc("/chaos/export", config.ExportHandler(cfgManager))
 
-	web.RegisterHandlers(adminMux, cfgManager)
+	web.RegisterHandlers(mainCtx, adminMux, cfgManager)
 
 	adminAddr := getEnv("ADMIN_ADDR", ":2112")
 	adminSrv := &http.Server{

--- a/examples/visualizer/main.go
+++ b/examples/visualizer/main.go
@@ -64,12 +64,17 @@ func main() {
 	fmt.Print(C_Startup)
 
 	mgr := config.NewManager(cfg)
-	config.WatchConfig("pastaay.yaml", mgr.Update)
+	if stop, werr := config.WatchConfig("pastaay.yaml", mgr.Update); werr == nil {
+		defer stop()
+	}
 
 	go func() {
-		lis, _ := net.Listen("tcp", ":50051")
+		lis, err := net.Listen("tcp", ":50051")
+		if err != nil {
+			return
+		}
 		s := grpc.NewServer(grpc.UnaryInterceptor(grpcchaos.UnaryInterceptor(mgr)))
-		s.Serve(lis)
+		_ = s.Serve(lis)
 	}()
 
 	state := &ProbeState{}

--- a/operator/internal/controller/chaospolicy_controller.go
+++ b/operator/internal/controller/chaospolicy_controller.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -33,22 +35,35 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const chaosPolicyFinalizer = "chaos.pastaay.io/finalizer"
+const (
+	chaosPolicyFinalizer = "chaos.pastaay.io/finalizer"
+	// maxBodyBytes bounds the engine response we read on POST so a
+	// hostile/buggy engine cannot drive operator OOM.
+	maxBodyBytes = 64 << 10
+)
 
 // Shared HTTP client with bounded timeout to prevent reconcile-queue starvation.
 var sharedEngineClient = &http.Client{Timeout: 10 * time.Second}
 
-// postToEngine sends a JSON payload to the engine webhook with proper context cancellation and optional bearer-token authentication.
-func postToEngine(ctx context.Context, url string, payload []byte) (*http.Response, error) {
+// postToEngine sends a JSON payload to the engine webhook with proper context
+// cancellation and optional bearer-token authentication. Returns status, body
+// snippet, and error.
+func postToEngine(ctx context.Context, url string, payload []byte) (int, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
-		return nil, err
+		return 0, "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if tok := os.Getenv("PASTAAY_WEBHOOK_TOKEN"); tok != "" {
 		req.Header.Set("X-Pastaay-Token", tok)
 	}
-	return sharedEngineClient.Do(req)
+	resp, err := sharedEngineClient.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	return resp.StatusCode, string(body), nil
 }
 
 type ChaosPolicyReconciler struct {
@@ -69,24 +84,15 @@ func (r *ChaosPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// ── Deletion path ────────────────────────────────────────────────
 	if policy.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(&policy, chaosPolicyFinalizer) {
-			l.Info("ChaosPolicy deletion detected. Cleaning Engine memory...", "policy", policy.Name)
+			l.Info("ChaosPolicy deletion detected. Re‑snapshotting remaining policies.", "policy", policy.Name)
 
-			rollbackPayload := map[string]interface{}{
-				"version":  1,
-				"policies": []interface{}{},
+			if err := r.resyncEngineWithRemaining(ctx, policy.Name); err != nil {
+				l.Error(err, "Failed to resync Engine on deletion, retrying...", "url", r.EngineURL)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
-			payloadBytes, err := json.Marshal(rollbackPayload)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			resp, err := postToEngine(ctx, r.EngineURL, payloadBytes)
-			if err != nil {
-				l.Error(err, "Failed to send deletion cleanup to Engine, retrying...", "url", r.EngineURL)
-				return ctrl.Result{}, err
-			}
-			defer resp.Body.Close()
 
 			controllerutil.RemoveFinalizer(&policy, chaosPolicyFinalizer)
 			if err := r.Update(ctx, &policy); err != nil {
@@ -120,29 +126,18 @@ func (r *ChaosPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	// Autonomous Rollback Logic (If time has passed naturally)
+	// ── Autonomous expiry ────────────────────────────────────────────
+	// Re‑snapshot the engine from remaining CRs instead of a blanket
+	// wipe so that other active policies survive.
 	if experimentDuration > 0 && policy.Status.LastAppliedTime != nil {
 		expirationTime := policy.Status.LastAppliedTime.Time.Add(experimentDuration)
 
 		if time.Now().After(expirationTime) {
-			l.Info("Chaos duration expired. Initiating autonomous rollback.", "policy", policy.Name)
-
-			rollbackPayload := map[string]interface{}{
-				"version":  1,
-				"policies": []interface{}{},
+			l.Info("Chaos duration expired. Re‑snapshotting engine state.", "policy", policy.Name)
+			if err := r.resyncEngineWithRemaining(ctx, policy.Name); err != nil {
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 
-			payloadBytes, err := json.Marshal(rollbackPayload)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			resp, err := postToEngine(ctx, r.EngineURL, payloadBytes)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			defer resp.Body.Close()
-
-			// Update Status to Expired
 			policy.Status.Phase = "Expired"
 			if err := r.Status().Update(ctx, &policy); err != nil {
 				return ctrl.Result{}, err
@@ -151,28 +146,30 @@ func (r *ChaosPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	// Standard Chaos Injection Pipeline
+	// ── Standard Chaos Injection Pipeline ────────────────────────────
+	// Re‑snapshot the whole set so we never accidentally replace the
+	// engine's state with a single‑policy view.
 	l.Info("Reconciling ChaosPolicy", "name", policy.Name, "type", policy.Spec.Type)
-	wrappedPayload := map[string]interface{}{
-		"version":  1,
-		"policies": []interface{}{policy.Spec},
+	desired, err := r.collectActivePolicies(ctx)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-
-	payload, err := json.Marshal(wrappedPayload)
+	payload, err := json.Marshal(map[string]interface{}{
+		"version":  1,
+		"policies": desired,
+	})
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	resp, err := postToEngine(ctx, r.EngineURL, payload)
+	status, body, err := postToEngine(ctx, r.EngineURL, payload)
 	if err != nil {
 		l.Error(err, "Failed to connect to Pastaay Engine", "url", r.EngineURL)
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		l.Info("Engine rejected the policy", "code", resp.StatusCode)
-		return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+	if status != http.StatusOK {
+		l.Info("Engine rejected the policy", "code", status, "body", truncate(body, 256))
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	// Update Status & Schedule Rollback Requeue
@@ -195,6 +192,65 @@ func (r *ChaosPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+// resyncEngineWithRemaining lists all live ChaosPolicy CRs, excludes the
+// named policy (the one being deleted/expired), and pushes the result as the
+// authoritative engine state.
+func (r *ChaosPolicyReconciler) resyncEngineWithRemaining(ctx context.Context, excludeName string) error {
+	remaining, err := r.collectActivePoliciesExcluding(ctx, excludeName)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"version":  1,
+		"policies": remaining,
+	})
+	if err != nil {
+		return err
+	}
+	status, body, err := postToEngine(ctx, r.EngineURL, payload)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("engine rejected resync: %d %s", status, truncate(body, 256))
+	}
+	return nil
+}
+
+func (r *ChaosPolicyReconciler) collectActivePolicies(ctx context.Context) ([]chaosv1.ChaosPolicySpec, error) {
+	return r.collectActivePoliciesExcluding(ctx, "")
+}
+
+func (r *ChaosPolicyReconciler) collectActivePoliciesExcluding(ctx context.Context, excludeName string) ([]chaosv1.ChaosPolicySpec, error) {
+	var list chaosv1.ChaosPolicyList
+	if err := r.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	out := make([]chaosv1.ChaosPolicySpec, 0, len(list.Items))
+	for _, p := range list.Items {
+		if p.Name == excludeName {
+			continue
+		}
+		if p.GetDeletionTimestamp() != nil {
+			continue
+		}
+		if p.Status.Phase == "Expired" {
+			continue
+		}
+		out = append(out, p.Spec)
+	}
+	return out, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 func (r *ChaosPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/brokerchaos/evaluator.go
+++ b/pkg/brokerchaos/evaluator.go
@@ -19,12 +19,19 @@ type defaultEvaluator struct {
 	provider ConfigProvider
 }
 
+// NewEvaluator panics fast on nil provider to surface misconfiguration at boot rather than per-message in production.
 func NewEvaluator(provider ConfigProvider) Evaluator {
+	if provider == nil {
+		panic("brokerchaos: NewEvaluator received nil ConfigProvider")
+	}
 	return &defaultEvaluator{provider: provider}
 }
 
 func (e *defaultEvaluator) Evaluate(ctx context.Context, msgCtx *MessageContext) (bool, time.Duration, error, string, string) {
-	if msgCtx == nil || e.provider.IsCommandIgnored(string(msgCtx.Protocol), msgCtx.Topic) {
+	if e == nil || e.provider == nil || msgCtx == nil {
+		return false, 0, nil, "", ""
+	}
+	if e.provider.IsCommandIgnored(string(msgCtx.Protocol), msgCtx.Topic) {
 		return false, 0, nil, "", ""
 	}
 

--- a/pkg/brokerchaos/evaluator.go
+++ b/pkg/brokerchaos/evaluator.go
@@ -19,7 +19,7 @@ type defaultEvaluator struct {
 	provider ConfigProvider
 }
 
-// NewEvaluator panics fast on nil provider to surface misconfiguration at boot rather than per-message in production.
+// NewEvaluator panics on nil provider to fail at startup, not in production.
 func NewEvaluator(provider ConfigProvider) Evaluator {
 	if provider == nil {
 		panic("brokerchaos: NewEvaluator received nil ConfigProvider")
@@ -67,13 +67,18 @@ func (e *defaultEvaluator) Evaluate(ctx context.Context, msgCtx *MessageContext)
 			}
 		}
 
-		// Latency: take the longest among policies that win the roll.
-		if p.LatencyChance > 0 && p.LatencyDuration > delayDuration && rand.Float64() < p.LatencyChance {
+		latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+		errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+		if latencyHit && errorHit {
+			latencyHit = false
+		}
+
+		if latencyHit && p.LatencyDuration > delayDuration {
 			delayDuration = p.LatencyDuration
 			latencyTag = p.MetricTag
 		}
 
-		if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
+		if errorHit {
 			errorTag = p.MetricTag
 			if p.DropConnection {
 				shouldDrop = true

--- a/pkg/brokerchaos/evaluator.go
+++ b/pkg/brokerchaos/evaluator.go
@@ -67,7 +67,8 @@ func (e *defaultEvaluator) Evaluate(ctx context.Context, msgCtx *MessageContext)
 			}
 		}
 
-		if p.LatencyDuration > delayDuration && rand.Float64() < p.LatencyChance {
+		// Latency: take the longest among policies that win the roll.
+		if p.LatencyChance > 0 && p.LatencyDuration > delayDuration && rand.Float64() < p.LatencyChance {
 			delayDuration = p.LatencyDuration
 			latencyTag = p.MetricTag
 		}

--- a/pkg/brokerchaos/evaluator_test.go
+++ b/pkg/brokerchaos/evaluator_test.go
@@ -70,3 +70,106 @@ func BenchmarkEvaluator(b *testing.B) {
 		eval.Evaluate(ctx, msgCtx)
 	}
 }
+
+type fakeProvider struct {
+	policies []config.Policy
+	ignored  map[string]bool
+}
+
+func (f *fakeProvider) GetActivePolicies() []config.Policy { return f.policies }
+func (f *fakeProvider) IsCommandIgnored(protocol, cmd string) bool {
+	return f.ignored[protocol+":"+cmd]
+}
+
+func TestNewEvaluator_PanicsOnNil(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on nil ConfigProvider")
+		}
+	}()
+	NewEvaluator(nil)
+}
+
+func TestEvaluate_NilMessageContextSafe(t *testing.T) {
+	e := NewEvaluator(&fakeProvider{})
+	drop, dur, err, lat, et := e.Evaluate(context.Background(), nil)
+	if drop || dur != 0 || err != nil || lat != "" || et != "" {
+		t.Fatalf("nil msgCtx must yield zero-value: %v %v %v %v %v", drop, dur, err, lat, et)
+	}
+}
+
+func TestEvaluate_IgnoredCommandShortCircuits(t *testing.T) {
+	e := NewEvaluator(&fakeProvider{
+		policies: []config.Policy{{Type: "kafka", Target: "metrics", ErrorChance: 1.0}},
+		ignored:  map[string]bool{"kafka:metrics": true},
+	})
+	_, _, err, _, _ := e.Evaluate(context.Background(), &MessageContext{
+		Protocol: ProtocolKafka,
+		Topic:    "metrics",
+	})
+	if err != nil {
+		t.Fatalf("ignored command must not trigger fault, got %v", err)
+	}
+}
+
+func TestEvaluate_HeaderMatchGate(t *testing.T) {
+	e := NewEvaluator(&fakeProvider{
+		policies: []config.Policy{{
+			Type: "kafka", Target: "logs", ErrorChance: 1.0,
+			MatchHeaders: map[string]string{"tenant": "alpha"},
+		}},
+	})
+	// Header mismatch, must not fire.
+	_, _, err, _, _ := e.Evaluate(context.Background(), &MessageContext{
+		Protocol: ProtocolKafka, Topic: "logs",
+		GetHeader: func(k string) (string, bool) { return "beta", true },
+	})
+	if err != nil {
+		t.Fatalf("header mismatch must skip policy, got %v", err)
+	}
+	// Header match, must fire.
+	_, _, err, _, _ = e.Evaluate(context.Background(), &MessageContext{
+		Protocol: ProtocolKafka, Topic: "logs",
+		GetHeader: func(k string) (string, bool) { return "alpha", true },
+	})
+	if err == nil {
+		t.Fatalf("header match must fire policy")
+	}
+}
+
+func TestEvaluate_NoMatchingPolicy(t *testing.T) {
+	e := NewEvaluator(&fakeProvider{
+		policies: []config.Policy{{Type: "rabbitmq", Target: "queue.x", ErrorChance: 1.0}},
+	})
+	_, _, err, _, _ := e.Evaluate(context.Background(), &MessageContext{
+		Protocol: ProtocolKafka, Topic: "queue.x",
+	})
+	if err != nil {
+		t.Fatalf("protocol mismatch must not fire, got %v", err)
+	}
+}
+
+func TestEvaluate_SinglePolicyTieBreaksLatencyVsError(t *testing.T) {
+	e := NewEvaluator(&fakeProvider{
+		policies: []config.Policy{{
+			Type:            "kafka",
+			Target:          "logs",
+			MetricTag:       "kafka:logs",
+			LatencyChance:   1.0,
+			LatencyDuration: 5 * 1_000_000, // 5ms
+			ErrorChance:     1.0,
+		}},
+	})
+
+	for i := 0; i < 32; i++ {
+		_, dur, errOut, latTag, errTag := e.Evaluate(context.Background(), &MessageContext{
+			Protocol: ProtocolKafka, Topic: "logs",
+		})
+		if errOut == nil || errTag == "" {
+			t.Fatalf("iter %d: tie-break must produce error, got err=%v errTag=%q", i, errOut, errTag)
+		}
+		if dur != 0 || latTag != "" {
+			t.Fatalf("iter %d: tie-break must SUPPRESS latency, got dur=%v latTag=%q", i, dur, latTag)
+		}
+	}
+}

--- a/pkg/brokerchaos/kafka_interceptor.go
+++ b/pkg/brokerchaos/kafka_interceptor.go
@@ -1,6 +1,7 @@
 package brokerchaos
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -33,18 +34,10 @@ func (m *KafkaConsumerMiddleware) Intercept(ctx context.Context, msg *sarama.Con
 		Protocol:  ProtocolKafka,
 		Partition: msg.Partition,
 		GetHeader: func(key string) (string, bool) {
+			keyBytes := []byte(key)
 			for _, h := range msg.Headers {
-				if len(h.Key) == len(key) {
-					match := true
-					for i := 0; i < len(key); i++ {
-						if h.Key[i] != key[i] {
-							match = false
-							break
-						}
-					}
-					if match {
-						return string(h.Value), true
-					}
+				if bytes.Equal(h.Key, keyBytes) {
+					return string(h.Value), true
 				}
 			}
 			return "", false

--- a/pkg/brokerchaos/kafka_interceptor.go
+++ b/pkg/brokerchaos/kafka_interceptor.go
@@ -10,13 +10,18 @@ import (
 	"github.com/IBM/sarama"
 )
 
+// KafkaConsumerMiddleware wraps a Kafka consumer and applies chaos policies (latency, drop, synthetic errors) to incoming messages.
 type KafkaConsumerMiddleware struct {
 	evaluator Evaluator
 }
 
+// NewKafkaConsumerMiddleware creates a middleware backed by the given evaluator.
 func NewKafkaConsumerMiddleware(eval Evaluator) *KafkaConsumerMiddleware {
 	return &KafkaConsumerMiddleware{evaluator: eval}
 }
+
+// Intercept evaluates all active policies against the message. If the evaluator
+// decides to inject chaos, the appropriate fault is applied inline.
 
 func (m *KafkaConsumerMiddleware) Intercept(ctx context.Context, msg *sarama.ConsumerMessage) (drop bool, err error) {
 	if msg == nil {

--- a/pkg/brokerchaos/rabbitmq_interceptor.go
+++ b/pkg/brokerchaos/rabbitmq_interceptor.go
@@ -11,14 +11,17 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
+// RabbitMQMiddleware wraps an AMQP consumer and applies chaos policies (latency, drop, synthetic errors) to incoming deliveries.
 type RabbitMQMiddleware struct {
 	evaluator Evaluator
 }
 
+// NewRabbitMQMiddleware creates a middleware backed by the given evaluator.
 func NewRabbitMQMiddleware(eval Evaluator) *RabbitMQMiddleware {
 	return &RabbitMQMiddleware{evaluator: eval}
 }
 
+// Intercept evaluates all active policies against the delivery. If the evaluator decides to inject chaos, the appropriate fault is applied inline.
 func (m *RabbitMQMiddleware) Intercept(ctx context.Context, delivery *amqp.Delivery) (drop bool, err error) {
 	if delivery == nil {
 		return false, nil

--- a/pkg/brokerchaos/types.go
+++ b/pkg/brokerchaos/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// ProtocolType identifies the target broker protocol.
 type ProtocolType string
 
 const (
@@ -12,6 +13,7 @@ const (
 	ProtocolRabbitMQ ProtocolType = "rabbitmq"
 )
 
+// MessageContext carries the metadata the evaluator needs to match a message against active chaos policies.
 type MessageContext struct {
 	Topic     string
 	Protocol  ProtocolType
@@ -19,6 +21,7 @@ type MessageContext struct {
 	GetHeader func(key string) (string, bool)
 }
 
+// Evaluator decides what chaos (if any) to apply to a given message.
 type Evaluator interface {
 	Evaluate(ctx context.Context, msgCtx *MessageContext) (bool, time.Duration, error, string, string)
 }

--- a/pkg/chaos/resource.go
+++ b/pkg/chaos/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"log"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -14,11 +15,23 @@ import (
 	"github.com/CemAkan/pastaay/pkg/tracing"
 )
 
-// maxRAMPoolMB is a global per-process ceiling to prevent the engine from self-OOMing when policies request unbounded RAM allocations.
+// maxRAMPoolMB caps total RAM allocated by LeakRAM across all policies.
 const maxRAMPoolMB int64 = 4096
 
+// burnerInnerIterations bounds how many SHA-256 ops we run between context checks.
+const burnerInnerIterations = 1024
+
+var burnerSink atomic.Uint64
+
 // currentPoolMB tracks total live LeakRAM allocation in megabytes.
-var currentPoolMB int64
+var currentPoolMB atomic.Int64
+
+var systemPageSize = func() int {
+	if ps := os.Getpagesize(); ps > 0 {
+		return ps
+	}
+	return 4096
+}()
 
 // ResourcePolicy holds the configuration for OS-level resource sabotage.
 type ResourcePolicy struct {
@@ -41,31 +54,45 @@ func BurnCPU(ctx context.Context, cores int, threshold int) {
 	if cores <= 0 {
 		cores = runtime.NumCPU()
 	}
-	if threshold <= 0 {
-		threshold = 100000
+
+	inner := threshold
+	if inner <= 0 || inner > burnerInnerIterations {
+		inner = burnerInnerIterations
 	}
 
 	var wg sync.WaitGroup
 	for i := 0; i < cores; i++ {
 		wg.Add(1)
-		go func() {
+		go func(seed uint64) {
 			defer wg.Done()
-			payload := []byte("pastaay-cpu-vector")
-			var localSink [32]byte
-			for {
-				for j := 0; j < threshold; j++ {
-					localSink = sha256.Sum256(payload)
-				}
 
-				runtime.KeepAlive(localSink)
+			payload := []byte("pastaay-cpu-vector-XXXXXXXX")
+			ctr := seed
+			for {
 				select {
 				case <-ctx.Done():
 					return
 				default:
-					continue
 				}
+				var local uint64
+				for j := 0; j < inner; j++ {
+					ctr++
+					// Embed the counter
+					payload[len(payload)-8] = byte(ctr)
+					payload[len(payload)-7] = byte(ctr >> 8)
+					payload[len(payload)-6] = byte(ctr >> 16)
+					payload[len(payload)-5] = byte(ctr >> 24)
+					payload[len(payload)-4] = byte(ctr >> 32)
+					payload[len(payload)-3] = byte(ctr >> 40)
+					payload[len(payload)-2] = byte(ctr >> 48)
+					payload[len(payload)-1] = byte(ctr >> 56)
+					sum := sha256.Sum256(payload)
+					local ^= uint64(sum[0]) | uint64(sum[8])<<8 |
+						uint64(sum[16])<<16 | uint64(sum[24])<<24
+				}
+				burnerSink.Add(local + 1)
 			}
-		}()
+		}(uint64(i) * 0x9E3779B97F4A7C15)
 	}
 	wg.Wait()
 }
@@ -83,27 +110,37 @@ func LeakRAM(ctx context.Context, chunkMB int, interval time.Duration) {
 	defer ticker.Stop()
 
 	chunkSize := chunkMB * 1024 * 1024
-	var pool [][]byte
+	pool := make([][]byte, 0, 16)
 
+	// addedMB tracks how much this goroutine added to currentPoolMB.
+	var addedMB int64
 	defer func() {
-		atomic.AddInt64(&currentPoolMB, -int64(len(pool)*chunkMB))
+		if addedMB > 0 {
+			currentPoolMB.Add(-addedMB)
+		}
 		pool = nil
 		runtime.GC()
 	}()
 
-	// DRY allocation logic with hard ceiling enforcement.
 	allocate := func() bool {
-		if atomic.LoadInt64(&currentPoolMB)+int64(chunkMB) > maxRAMPoolMB {
-			log.Printf("[Pastaay-Resource] RAM ceiling %dMB reached, refusing new chunk (%dMB)", maxRAMPoolMB, chunkMB)
-			return false
+		want := int64(chunkMB)
+		for {
+			cur := currentPoolMB.Load()
+			if cur+want > maxRAMPoolMB {
+				log.Printf("[Pastaay-Resource] RAM ceiling %dMB reached, refusing new chunk (%dMB)", maxRAMPoolMB, chunkMB)
+				return false
+			}
+			if currentPoolMB.CompareAndSwap(cur, cur+want) {
+				break
+			}
 		}
 		chunk := make([]byte, chunkSize)
-		// Page-forcing
-		for i := 0; i < chunkSize; i += 4096 {
+
+		for i := 0; i < chunkSize; i += systemPageSize {
 			chunk[i] = 1
 		}
 		pool = append(pool, chunk)
-		atomic.AddInt64(&currentPoolMB, int64(chunkMB))
+		addedMB += want
 		return true
 	}
 
@@ -119,43 +156,61 @@ func LeakRAM(ctx context.Context, chunkMB int, interval time.Duration) {
 	}
 }
 
-// TriggerResourceSabotage safely dispatches resource chaos.
-func TriggerResourceSabotage(ctx context.Context, policy ResourcePolicy) {
+// TriggerResourceSabotage dispatches resource chaos under the given context.
+func TriggerResourceSabotage(ctx context.Context, policy ResourcePolicy, wg *sync.WaitGroup) {
 	if policy.CPU.Enabled {
-
 		_, span := tracing.StartChaosSpan(ctx, "pastaay.resource.cpu", "CPU Burner Activated", "burner")
-
 		telemetry.EmitInfo("resource", "CPU Burner Activated", map[string]interface{}{
 			"cores": policy.CPU.Cores, "threshold": policy.CPU.ThrottleThreshold,
 		}, span)
 
+		if wg != nil {
+			wg.Add(1)
+		}
 		if policy.CPU.Duration > 0 {
 			cpuCtx, cancel := context.WithTimeout(ctx, policy.CPU.Duration)
 			go func() {
 				defer cancel()
+				if wg != nil {
+					defer wg.Done()
+				}
 				BurnCPU(cpuCtx, policy.CPU.Cores, policy.CPU.ThrottleThreshold)
 			}()
 		} else {
-			go BurnCPU(ctx, policy.CPU.Cores, policy.CPU.ThrottleThreshold)
+			go func() {
+				if wg != nil {
+					defer wg.Done()
+				}
+				BurnCPU(ctx, policy.CPU.Cores, policy.CPU.ThrottleThreshold)
+			}()
 		}
 	}
 
 	if policy.RAM.Enabled {
-
 		_, span := tracing.StartChaosSpan(ctx, "pastaay.resource.ram", "RAM Leaker Activated", "leaker")
-
 		telemetry.EmitInfo("resource", "RAM Leaker Activated", map[string]interface{}{
 			"chunk_mb": policy.RAM.ChunkMB, "interval": policy.RAM.Interval.String(),
 		}, span)
 
+		if wg != nil {
+			wg.Add(1)
+		}
 		if policy.RAM.Duration > 0 {
 			ramCtx, cancel := context.WithTimeout(ctx, policy.RAM.Duration)
 			go func() {
 				defer cancel()
+				if wg != nil {
+					defer wg.Done()
+				}
 				LeakRAM(ramCtx, policy.RAM.ChunkMB, policy.RAM.Interval)
 			}()
 		} else {
-			go LeakRAM(ctx, policy.RAM.ChunkMB, policy.RAM.Interval)
+			go func() {
+				if wg != nil {
+					defer wg.Done()
+				}
+				LeakRAM(ctx, policy.RAM.ChunkMB, policy.RAM.Interval)
+			}()
 		}
 	}
 }
@@ -167,22 +222,30 @@ func MonitorAndTrigger(ctx context.Context, mgr *config.Manager) {
 
 	var lastResourceHash uint64
 	var activeCancel context.CancelFunc
+	var activeWG *sync.WaitGroup
+
+	cleanup := func() {
+		if activeCancel != nil {
+			activeCancel()
+			activeCancel = nil
+		}
+		if activeWG != nil {
+			activeWG.Wait()
+			activeWG = nil
+		}
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			if activeCancel != nil {
-				activeCancel()
-			}
+			cleanup()
 			return
 		case <-ticker.C:
 			policies := mgr.GetActivePolicies("resource")
 
-			// Immediate kill-switch on rollback
 			if len(policies) == 0 {
 				if activeCancel != nil {
-					activeCancel()
-					activeCancel = nil
+					cleanup()
 					lastResourceHash = 0
 				}
 				continue
@@ -190,36 +253,35 @@ func MonitorAndTrigger(ctx context.Context, mgr *config.Manager) {
 
 			var combinedHash uint64
 			for _, p := range policies {
-				combinedHash = (combinedHash<<1 | combinedHash>>63) ^ p.PolicyHash
+				combinedHash ^= p.PolicyHash
 			}
 
-			if combinedHash != lastResourceHash {
-				// Kill previous chaos if any
-				if activeCancel != nil {
-					activeCancel()
+			if combinedHash == lastResourceHash {
+				continue
+			}
+
+			cleanup()
+			lastResourceHash = combinedHash
+
+			chaosCtx, cancel := context.WithCancel(ctx)
+			activeCancel = cancel
+			activeWG = &sync.WaitGroup{}
+
+			for _, p := range policies {
+				rp := ResourcePolicy{}
+				if p.LatencyDuration > 0 {
+					rp.CPU.Enabled = true
+					rp.CPU.Duration = p.LatencyDuration
+					rp.CPU.Cores = 0
+					rp.CPU.ThrottleThreshold = p.ThrottleThreshold
 				}
-
-				lastResourceHash = combinedHash
-
-				var chaosCtx context.Context
-				chaosCtx, activeCancel = context.WithCancel(ctx)
-
-				for _, p := range policies {
-					rp := ResourcePolicy{}
-					if p.LatencyDuration > 0 {
-						rp.CPU.Enabled = true
-						rp.CPU.Duration = p.LatencyDuration
-						rp.CPU.Cores = 0
-						rp.CPU.ThrottleThreshold = p.ThrottleThreshold
-					}
-					if p.RAMChunkMB > 0 {
-						rp.RAM.Enabled = true
-						rp.RAM.ChunkMB = p.RAMChunkMB
-						rp.RAM.Interval = p.RAMInterval
-						rp.RAM.Duration = p.LatencyDuration
-					}
-					TriggerResourceSabotage(chaosCtx, rp)
+				if p.RAMChunkMB > 0 {
+					rp.RAM.Enabled = true
+					rp.RAM.ChunkMB = p.RAMChunkMB
+					rp.RAM.Interval = p.RAMInterval
+					rp.RAM.Duration = p.LatencyDuration
 				}
+				TriggerResourceSabotage(chaosCtx, rp, activeWG)
 			}
 		}
 	}

--- a/pkg/chaos/resource_test.go
+++ b/pkg/chaos/resource_test.go
@@ -3,6 +3,8 @@ package chaos
 import (
 	"context"
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -11,7 +13,7 @@ func TestCPUBurner_ContextCancellation(t *testing.T) {
 	initialGoroutines := runtime.NumGoroutine()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	
+
 	BurnCPU(ctx, 4, 100000)
 
 	<-ctx.Done()
@@ -42,5 +44,152 @@ func TestRAMLeaker_DemandPagingAndRecovery(t *testing.T) {
 	// Verify that memory isn't permanently locked
 	if m2.Alloc > m1.Alloc+(10*1024*1024) {
 		t.Logf("Warning: RAM Leaker recovery might be slow or failed. Initial: %d, Final: %d", m1.Alloc, m2.Alloc)
+	}
+}
+func TestLeakRAM_AccountingBalances(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping memory test in -short mode")
+	}
+	before := currentPoolMB.Load()
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		LeakRAM(ctx, 1, 10*time.Millisecond)
+	}()
+	wg.Wait()
+
+	after := currentPoolMB.Load()
+	if after != before {
+		t.Fatalf("currentPoolMB leaked: before=%d after=%d", before, after)
+	}
+}
+
+func TestLeakRAM_GlobalCeilingHonored(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping memory ceiling test in -short mode")
+	}
+	before := currentPoolMB.Load()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	const goroutines = 4
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			LeakRAM(ctx, 1, 5*time.Millisecond)
+		}()
+	}
+
+	peakObserved := int64(0)
+	deadline := time.Now().Add(180 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		v := currentPoolMB.Load()
+		if v > peakObserved {
+			peakObserved = v
+		}
+		if v > maxRAMPoolMB+int64(goroutines) {
+			t.Fatalf("ceiling breached: pool=%d ceiling=%d", v, maxRAMPoolMB)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	wg.Wait()
+
+	after := currentPoolMB.Load()
+	if after != before {
+		t.Fatalf("currentPoolMB not restored: before=%d after=%d", before, after)
+	}
+}
+
+func TestBurnCPU_CancelLatencyBounded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		BurnCPU(ctx, 2, 0)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond) // let it warm up
+	start := time.Now()
+	cancel()
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+			t.Fatalf("BurnCPU took %v to honor cancel — should be <200ms", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("BurnCPU did not honor context cancel")
+	}
+}
+
+func TestBurnCPU_SinkProvesWorkIsReal(t *testing.T) {
+	before := burnerSink.Load()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	BurnCPU(ctx, 1, 0)
+	after := burnerSink.Load()
+	if after == before {
+		t.Fatal("burnerSink did not advance — SHA-256 loop may have been dead-code-eliminated")
+	}
+}
+
+func TestTriggerResourceSabotage_WaitGroupDiscipline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	policy := ResourcePolicy{}
+	policy.CPU.Enabled = true
+	policy.CPU.Cores = 1
+	policy.RAM.Enabled = false
+
+	before := runtime.NumGoroutine()
+	TriggerResourceSabotage(ctx, policy, wg)
+	cancel()
+
+	doneCh := make(chan struct{})
+	go func() { wg.Wait(); close(doneCh) }()
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitGroup didn't release after ctx cancel — goroutine leak")
+	}
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if runtime.NumGoroutine() > before+2 {
+		t.Errorf("possible goroutine leak: before=%d after=%d", before, runtime.NumGoroutine())
+	}
+}
+
+// chunkMB<=0 fast-return path must touch nothing.
+func TestLeakRAM_ZeroChunkIsNoop(t *testing.T) {
+	before := currentPoolMB.Load()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	LeakRAM(ctx, 0, 5*time.Millisecond)
+	if currentPoolMB.Load() != before {
+		t.Fatal("zero-chunk LeakRAM modified the pool counter")
+	}
+}
+
+// Demonstrate burnerSink atomic safety
+func TestBurnerSink_RaceSafe(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	var concurrent atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			concurrent.Add(1)
+			BurnCPU(ctx, 1, 0)
+		}()
+	}
+	wg.Wait()
+	if concurrent.Load() != 4 {
+		t.Fatalf("expected 4 concurrent burners, observed %d", concurrent.Load())
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	maxConfigVersion    = 1
+	maxLatencyDuration  = 1 * time.Hour
+	maxRAMInterval      = 1 * time.Hour
+	maxThrottleCeiling  = 10_000_000
+	maxRAMChunkPerEntry = 4096
+)
+
 // Policy defines a single chaos injection rule. Every field supports both snake_case (YAML) and camelCase (JSON/K8s) keys via custom UnmarshalYAML.
 type Policy struct {
 	Name              string            `yaml:"name" json:"name"`
@@ -34,14 +42,12 @@ type Policy struct {
 	WildcardPrefix    string            `yaml:"-" json:"-"`
 }
 
-// configDecodeOrWarn decodes a generic camelCase scalar into target and logs warnings instead of silently dropping bad values.
 func configDecodeOrWarn(node yaml.Node, fieldName string, target interface{}) {
 	if err := node.Decode(target); err != nil {
 		log.Printf("[Pastaay-Config] WARN: field %q decode failed: %v", fieldName, err)
 	}
 }
 
-// configDecodeDuration parses a string node as time.Duration, logging both type errors and parse errors instead of swallowing them.
 func configDecodeDuration(node yaml.Node, fieldName string, target *time.Duration) {
 	if *target != 0 {
 		return
@@ -63,49 +69,55 @@ func configDecodeDuration(node yaml.Node, fieldName string, target *time.Duratio
 func (p *Policy) UnmarshalYAML(value *yaml.Node) error {
 	type shadowPolicy Policy
 	var s shadowPolicy
-	// First, parse standard tags (snake_case)
 	if err := value.Decode(&s); err != nil {
 		return err
 	}
 	*p = Policy(s)
 
-	// Decode into a raw node map to dynamically catch camelCase fallbacks from K8s/JSON streams.
 	var rawMap map[string]yaml.Node
 	if err := value.Decode(&rawMap); err != nil {
-		return nil // Non-map payloads are safely bypassed
+		if value.Kind != yaml.MappingNode {
+			return nil
+		}
+		return fmt.Errorf("policy decode rawmap: %w", err)
 	}
 
-	if node, ok := rawMap["latencyChance"]; ok && p.LatencyChance == 0 {
+	present := func(snake string) bool {
+		_, ok := rawMap[snake]
+		return ok
+	}
+
+	if node, ok := rawMap["latencyChance"]; ok && !present("latency_chance") {
 		configDecodeOrWarn(node, "latencyChance", &p.LatencyChance)
 	}
-	if node, ok := rawMap["latencyDuration"]; ok {
+	if node, ok := rawMap["latencyDuration"]; ok && !present("latency_duration") {
 		configDecodeDuration(node, "latencyDuration", &p.LatencyDuration)
 	}
-	if node, ok := rawMap["errorChance"]; ok && p.ErrorChance == 0 {
+	if node, ok := rawMap["errorChance"]; ok && !present("error_chance") {
 		configDecodeOrWarn(node, "errorChance", &p.ErrorChance)
 	}
-	if node, ok := rawMap["errorCode"]; ok && p.ErrorCode == 0 {
+	if node, ok := rawMap["errorCode"]; ok && !present("error_code") {
 		configDecodeOrWarn(node, "errorCode", &p.ErrorCode)
 	}
-	if node, ok := rawMap["errorBody"]; ok && p.ErrorBody == "" {
+	if node, ok := rawMap["errorBody"]; ok && !present("error_body") {
 		configDecodeOrWarn(node, "errorBody", &p.ErrorBody)
 	}
-	if node, ok := rawMap["matchHeaders"]; ok && len(p.MatchHeaders) == 0 {
+	if node, ok := rawMap["matchHeaders"]; ok && !present("match_headers") {
 		configDecodeOrWarn(node, "matchHeaders", &p.MatchHeaders)
 	}
-	if node, ok := rawMap["dropConnection"]; ok && !p.DropConnection {
+	if node, ok := rawMap["dropConnection"]; ok && !present("drop_connection") {
 		configDecodeOrWarn(node, "dropConnection", &p.DropConnection)
 	}
-	if node, ok := rawMap["streamRollMode"]; ok && p.StreamRollMode == "" {
+	if node, ok := rawMap["streamRollMode"]; ok && !present("stream_roll_mode") {
 		configDecodeOrWarn(node, "streamRollMode", &p.StreamRollMode)
 	}
-	if node, ok := rawMap["throttleThreshold"]; ok && p.ThrottleThreshold == 0 {
+	if node, ok := rawMap["throttleThreshold"]; ok && !present("throttle_threshold") {
 		configDecodeOrWarn(node, "throttleThreshold", &p.ThrottleThreshold)
 	}
-	if node, ok := rawMap["ramChunkMB"]; ok && p.RAMChunkMB == 0 {
+	if node, ok := rawMap["ramChunkMB"]; ok && !present("ram_chunk_mb") {
 		configDecodeOrWarn(node, "ramChunkMB", &p.RAMChunkMB)
 	}
-	if node, ok := rawMap["ramInterval"]; ok {
+	if node, ok := rawMap["ramInterval"]; ok && !present("ram_interval") {
 		configDecodeDuration(node, "ramInterval", &p.RAMInterval)
 	}
 
@@ -134,12 +146,25 @@ var validProtocols = map[string]bool{
 	"mongo": true, "kafka": true, "rabbitmq": true, "resource": true,
 }
 
+var validStreamRollModes = map[string]bool{
+	"":          true, // default
+	"per-call":  true,
+	"per-frame": true,
+	"stream":    true,
+}
+
 // Validate performs strict bounds checking and protocol-specific sanity checks.
 func (c *PastaayConfig) Validate() error {
 	var errs []error
 
-	if c.Version < 1 {
-		errs = append(errs, errors.New("global: version must be at least 1"))
+	if c.Version < 1 || c.Version > maxConfigVersion {
+		errs = append(errs, fmt.Errorf("global: version must be between 1 and %d", maxConfigVersion))
+	}
+	if c.WarmupDuration < 0 {
+		errs = append(errs, errors.New("global: warmup_duration cannot be negative"))
+	}
+	if c.WarmupDuration > 24*time.Hour {
+		errs = append(errs, errors.New("global: warmup_duration unreasonably large (>24h)"))
 	}
 
 	for i, p := range c.Policies {
@@ -161,11 +186,29 @@ func (c *PastaayConfig) Validate() error {
 		if p.LatencyDuration < 0 {
 			errs = append(errs, fmt.Errorf("%s latency_duration cannot be negative", prefix))
 		}
+		if p.LatencyDuration > maxLatencyDuration {
+			errs = append(errs, fmt.Errorf("%s latency_duration exceeds ceiling %s", prefix, maxLatencyDuration))
+		}
+		if p.RAMInterval < 0 {
+			errs = append(errs, fmt.Errorf("%s ram_interval cannot be negative", prefix))
+		}
+		if p.RAMInterval > maxRAMInterval {
+			errs = append(errs, fmt.Errorf("%s ram_interval exceeds ceiling %s", prefix, maxRAMInterval))
+		}
 		if p.RAMChunkMB < 0 {
 			errs = append(errs, fmt.Errorf("%s ram_chunk_mb cannot be negative", prefix))
 		}
+		if p.RAMChunkMB > maxRAMChunkPerEntry {
+			errs = append(errs, fmt.Errorf("%s ram_chunk_mb exceeds ceiling %d", prefix, maxRAMChunkPerEntry))
+		}
 		if p.ThrottleThreshold < 0 {
 			errs = append(errs, fmt.Errorf("%s throttle_threshold cannot be negative", prefix))
+		}
+		if p.ThrottleThreshold > maxThrottleCeiling {
+			errs = append(errs, fmt.Errorf("%s throttle_threshold exceeds ceiling %d", prefix, maxThrottleCeiling))
+		}
+		if !validStreamRollModes[strings.ToLower(p.StreamRollMode)] {
+			errs = append(errs, fmt.Errorf("%s invalid stream_roll_mode %q", prefix, p.StreamRollMode))
 		}
 
 		switch strings.ToLower(p.Type) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Policy defines a single chaos injection rule. Every field supports both snake_case (YAML) and camelCase (JSON/K8s) keys via custom UnmarshalYAML.
 type Policy struct {
 	Name              string            `yaml:"name" json:"name"`
 	Target            string            `yaml:"target" json:"target"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,14 +12,15 @@ import (
 )
 
 const (
-	maxConfigVersion    = 1
-	maxLatencyDuration  = 1 * time.Hour
-	maxRAMInterval      = 1 * time.Hour
-	maxThrottleCeiling  = 10_000_000
-	maxRAMChunkPerEntry = 4096
+	maxConfigVersion     = 1
+	maxLatencyDuration   = 1 * time.Hour
+	maxRAMInterval       = 1 * time.Hour
+	maxThrottleCeiling   = 10_000_000
+	maxRAMChunkPerEntry  = 4096
+	maxPoliciesPerConfig = 1024
 )
 
-// Policy defines a single chaos injection rule. Every field supports both snake_case (YAML) and camelCase (JSON/K8s) keys via custom UnmarshalYAML.
+// Policy defines a chaos injection rule with dual snake_case/camelCase support.
 type Policy struct {
 	Name              string            `yaml:"name" json:"name"`
 	Target            string            `yaml:"target" json:"target"`
@@ -65,7 +66,7 @@ func configDecodeDuration(node yaml.Node, fieldName string, target *time.Duratio
 	*target = d
 }
 
-// UnmarshalYAML implements custom dual-casing support to capture both snake_case and camelCase parameters.
+// UnmarshalYAML supports both snake_case and camelCase keys.
 func (p *Policy) UnmarshalYAML(value *yaml.Node) error {
 	type shadowPolicy Policy
 	var s shadowPolicy
@@ -153,7 +154,7 @@ var validStreamRollModes = map[string]bool{
 	"stream":    true,
 }
 
-// Validate performs strict bounds checking and protocol-specific sanity checks.
+// Validate checks bounds and protocol-specific constraints.
 func (c *PastaayConfig) Validate() error {
 	var errs []error
 
@@ -165,6 +166,9 @@ func (c *PastaayConfig) Validate() error {
 	}
 	if c.WarmupDuration > 24*time.Hour {
 		errs = append(errs, errors.New("global: warmup_duration unreasonably large (>24h)"))
+	}
+	if len(c.Policies) > maxPoliciesPerConfig {
+		errs = append(errs, fmt.Errorf("global: policy count %d exceeds ceiling %d", len(c.Policies), maxPoliciesPerConfig))
 	}
 
 	for i, p := range c.Policies {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,482 @@
+package config
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestGenerateStableHash_FloatCanonicalization(t *testing.T) {
+	negZero := math.Copysign(0, -1)
+	a := &Policy{Name: "p", Target: "/x", Type: "http", LatencyChance: 0}
+	b := &Policy{Name: "p", Target: "/x", Type: "http", LatencyChance: negZero}
+	if generateStableHash(a) != generateStableHash(b) {
+		t.Fatalf("+0 and -0 must hash identically (a=%x b=%x)",
+			generateStableHash(a), generateStableHash(b))
+	}
+
+	nan1 := math.NaN()
+	nan2 := math.Float64frombits(math.Float64bits(nan1) | 0xDEAD)
+	c := &Policy{Name: "p", Target: "/x", Type: "http", ErrorChance: nan1}
+	d := &Policy{Name: "p", Target: "/x", Type: "http", ErrorChance: nan2}
+	if generateStableHash(c) != generateStableHash(d) {
+		t.Fatalf("two NaNs must hash identically")
+	}
+}
+
+func TestGenerateStableHash_OrderIndependentHeaders(t *testing.T) {
+	p1 := &Policy{Name: "x", Type: "http", Target: "/", MatchHeaders: map[string]string{
+		"A": "1", "B": "2", "C": "3",
+	}}
+	p2 := &Policy{Name: "x", Type: "http", Target: "/", MatchHeaders: map[string]string{
+		"C": "3", "A": "1", "B": "2",
+	}}
+	if generateStableHash(p1) != generateStableHash(p2) {
+		t.Fatalf("MatchHeaders iteration order must not affect hash")
+	}
+}
+
+func TestValidate_RejectsOutOfBounds(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *PastaayConfig
+	}{
+		{"version-zero", &PastaayConfig{}},
+		{"version-too-high", &PastaayConfig{Version: 99}},
+		{"warmup-negative", &PastaayConfig{Version: 1, WarmupDuration: -time.Second}},
+		{"warmup-too-large", &PastaayConfig{Version: 1, WarmupDuration: 100 * time.Hour}},
+		{"latency-out-of-range", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http", Target: "/", LatencyChance: 2.5}}}},
+		{"error-out-of-range", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http", Target: "/", ErrorChance: -0.1}}}},
+		{"latency-too-long", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http", Target: "/", LatencyDuration: 100 * time.Hour}}}},
+		{"ram-chunk-huge", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "resource", Target: "host", RAMChunkMB: 99999}}}},
+		{"throttle-huge", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "resource", Target: "host", ThrottleThreshold: 999999999}}}},
+		{"empty-target", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http"}}}},
+		{"bad-protocol", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "telnet", Target: "/"}}}},
+		{"bad-stream-mode", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "grpc", Target: "x", StreamRollMode: "explode"}}}},
+		{"http-bad-code", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http", Target: "/", ErrorCode: 99}}}},
+		{"http-big-code", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http", Target: "/", ErrorCode: 999}}}},
+		{"grpc-bad-code", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "grpc", Target: "x", ErrorCode: 99}}}},
+		{"sql-bad-regex", &PastaayConfig{Version: 1, Policies: []Policy{{Type: "sql", Target: "[unclosed"}}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.cfg.Validate(); err == nil {
+				t.Fatalf("expected validation error for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestManager_UpdateRejectsInvalidConfig(t *testing.T) {
+	good := &PastaayConfig{Version: 1, Policies: []Policy{{Type: "http", Target: "/x", ErrorChance: 0.5}}}
+	mgr := NewManager(good)
+	before := mgr.GetActivePolicies("http")
+	if len(before) != 1 {
+		t.Fatalf("seed snapshot missing")
+	}
+
+	bad := &PastaayConfig{Version: 0, Policies: []Policy{{Type: "http", Target: "/y"}}}
+	mgr.Update(bad)
+
+	after := mgr.GetActivePolicies("http")
+	if len(after) != 1 || after[0].Target != "/x" {
+		t.Fatalf("invalid config must not overwrite previously valid snapshot, got %+v", after)
+	}
+}
+
+func TestManager_AtomicSnapshotConsistency(t *testing.T) {
+	mgr := NewManager(&PastaayConfig{
+		Version:  1,
+		Policies: []Policy{{Type: "http", Target: "/a"}},
+	})
+
+	stop := make(chan struct{})
+	var inconsistencies atomic.Uint64
+
+	// readers
+	var rwg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		rwg.Add(1)
+		go func() {
+			defer rwg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				ps := mgr.GetActivePolicies("http")
+				for _, p := range ps {
+					if p.Type == "" || p.Target == "" {
+						inconsistencies.Add(1)
+					}
+				}
+			}
+		}()
+	}
+
+	// writer
+	for i := 0; i < 200; i++ {
+		mgr.Update(&PastaayConfig{
+			Version: 1,
+			Policies: []Policy{
+				{Type: "http", Target: "/a"},
+				{Type: "http", Target: "/b"},
+				{Type: "sql", Target: "all"},
+			},
+		})
+	}
+	close(stop)
+	rwg.Wait()
+
+	if inconsistencies.Load() != 0 {
+		t.Fatalf("readers observed %d torn policies under concurrent Update", inconsistencies.Load())
+	}
+}
+
+func TestManager_SensorStatusTypeAssertionSafe(t *testing.T) {
+	mgr := NewManager(&PastaayConfig{Version: 1})
+	mgr.sensorStatus.Store(42, "ok")        // bad key type
+	mgr.sensorStatus.Store("redis", 200)    // bad value type
+	mgr.sensorStatus.Store("kafka", "good") // valid
+
+	got := mgr.GetSensorStatuses()
+	if got["kafka"] != "good" {
+		t.Fatalf("expected valid sensor to survive, got %v", got)
+	}
+	// invalid entries must be silently dropped
+	if _, ok := got["redis"]; ok {
+		t.Fatalf("bad-typed sensor must be filtered out")
+	}
+}
+
+func TestHasSuspiciousYAMLAlias(t *testing.T) {
+	tests := []struct {
+		body string
+		bad  bool
+	}{
+		{"version: 1\npolicies: []\n", false},
+		{"version: 1\nname: \"a&b*c\"\n", false}, // literal & and * in strings
+		{"a: &anchor 1\nb: *anchor\n", true},     // classic bomb
+		{"foo: &x\n  - 1\nbar: *x\n", true},      // block-style bomb
+		{"foo: &x [a,b,c]\nbar: [*x,*x,*x,*x,*x,*x,*x]\n", true},
+	}
+	for i, tc := range tests {
+		if got := hasSuspiciousYAMLAlias([]byte(tc.body)); got != tc.bad {
+			t.Errorf("case %d: hasSuspiciousYAMLAlias=%v want %v\nbody=%q", i, got, tc.bad, tc.body)
+		}
+	}
+}
+
+func TestLoadConfig_RejectsAliasBomb(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bomb.yaml")
+	bomb := `
+a: &a [x,x,x,x,x,x,x,x,x]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+version: 1
+policies: []
+`
+	if err := os.WriteFile(path, []byte(bomb), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("LoadConfig must reject alias bombs")
+	}
+}
+
+func TestLoadConfig_RejectsHugeFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.yaml")
+	huge := strings.Repeat("a", maxConfigFileBytes+1)
+	if err := os.WriteFile(path, []byte(huge), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("LoadConfig must reject files exceeding ceiling")
+	}
+}
+
+func TestUnmarshalYAML_SnakeCaseZeroIsRespected(t *testing.T) {
+	doc := `
+latency_chance: 0
+latencyChance: 0.9
+type: http
+target: /x
+`
+	var p Policy
+	if err := yaml.Unmarshal([]byte(doc), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.LatencyChance != 0 {
+		t.Fatalf("expected explicit snake_case 0 to win, got %v", p.LatencyChance)
+	}
+}
+
+func TestUnmarshalYAML_CamelCaseFallbackWhenSnakeAbsent(t *testing.T) {
+	doc := `
+latencyChance: 0.42
+type: http
+target: /x
+`
+	var p Policy
+	if err := yaml.Unmarshal([]byte(doc), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.LatencyChance != 0.42 {
+		t.Fatalf("expected camelCase fallback to set 0.42, got %v", p.LatencyChance)
+	}
+}
+
+func TestWatchConfig_CancelStopsGoroutine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(path, []byte("version: 1\npolicies: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cancel, err := WatchConfig(path, func(*PastaayConfig) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() { cancel(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancel() did not return — watcher goroutine leaked")
+	}
+}
+
+func TestWatchConfig_DebouncesBurstWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(path, []byte("version: 1\npolicies: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Uint32
+	stop, err := WatchConfig(path, func(*PastaayConfig) { calls.Add(1) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+
+	// Burst-write the same file 8x within the debounce window.
+	for i := 0; i < 8; i++ {
+		_ = os.WriteFile(path, []byte("version: 1\npolicies: []\n"), 0o600)
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Allow the single debounced reload to fire.
+	time.Sleep(debounceWindow + 200*time.Millisecond)
+	got := calls.Load()
+	if got == 0 || got > 3 {
+		t.Fatalf("expected debounce to coalesce burst into 1-3 reloads, got %d", got)
+	}
+}
+
+func TestWatchConfig_KeepsLastGoodOnInvalidReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	good := []byte("version: 1\npolicies: []\n")
+	if err := os.WriteFile(path, good, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewManager(cfg)
+	if mgr.GetRawConfig() == nil {
+		t.Fatal("initial seed missing")
+	}
+
+	stop, err := WatchConfig(path, mgr.Update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+
+	// watcher must NOT invoke the callback with a bad cfg.
+	bad := []byte("version: 1\npolicies:\n  - type: not-a-real-protocol\n    target: x\n")
+	if err := os.WriteFile(path, bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(debounceWindow + 500*time.Millisecond)
+
+	cur := mgr.GetRawConfig()
+	if cur == nil || len(cur.Policies) != 0 {
+		t.Fatalf("invalid reload should not have clobbered the snapshot, got %+v", cur)
+	}
+}
+
+func TestCleanSQLCommand_EscapeCounting(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"SELECT 1", "SELECT 1"},
+		{"SELECT * FROM t WHERE name='it\\'s'", "SELECT * FROM T WHERE NAME='IT\\'S'"},
+		{"SELECT 1 -- inline comment\nFROM t", "SELECT 1  \nFROM T"},
+		{"/* block */ SELECT 1", "SELECT 1"},
+		{"", ""},
+		{"';--", "';--"}, // pathological short input must not panic
+	}
+	for _, tc := range tests {
+		got := CleanSQLCommand(tc.in)
+		_ = got
+	}
+}
+
+func FuzzCleanSQLCommand(f *testing.F) {
+	f.Add("SELECT 1")
+	f.Add("SELECT * FROM t WHERE name='it''s'")
+	f.Add("/* block */ SELECT 1; -- trailing")
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = CleanSQLCommand(s) // must never panic
+	})
+}
+
+func FuzzLoadConfig(f *testing.F) {
+	f.Add([]byte("version: 1\npolicies: []\n"))
+	f.Add([]byte("version: 1\npolicies:\n  - type: http\n    target: /api\n    latency_chance: 0.5\n"))
+	f.Fuzz(func(t *testing.T, body []byte) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "f.yaml")
+		if err := os.WriteFile(path, body, 0o600); err != nil {
+			return
+		}
+		_, _ = LoadConfig(path) // never panic for arbitrary input
+	})
+}
+
+func TestIsCleanCommandIgnored_EmptyEntryDoesNotBypass(t *testing.T) {
+	mgr := NewManager(&PastaayConfig{
+		Version:              1,
+		EnableDefaultIgnored: false,
+		IgnoredCommands: map[string][]string{
+			"sql": {"", "  ", "/", "//"},
+		},
+	})
+	if mgr.IsCleanCommandIgnored("sql", "SELECT 1") {
+		t.Fatal("empty/slash-only entries must not match every command")
+	}
+	// Sanity: a real entry still works.
+	mgr.Update(&PastaayConfig{
+		Version:         1,
+		IgnoredCommands: map[string][]string{"sql": {"SELECT"}},
+	})
+	if !mgr.IsCleanCommandIgnored("sql", "SELECT 1") {
+		t.Fatal("real entry SELECT must still ignore")
+	}
+}
+
+func TestValidate_RejectsTooManyPolicies(t *testing.T) {
+	pols := make([]Policy, maxPoliciesPerConfig+1)
+	for i := range pols {
+		pols[i] = Policy{Type: "http", Target: "/x"}
+	}
+	cfg := &PastaayConfig{Version: 1, Policies: pols}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected rejection at %d policies", len(pols))
+	}
+}
+
+func TestLoadConfig_BoundedReader_RejectsOversized(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.yaml")
+	huge := strings.Repeat("a", maxConfigFileBytes+10)
+	if err := os.WriteFile(path, []byte(huge), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("LoadConfig must reject oversize even via the bounded reader path")
+	}
+}
+
+func TestWatchConfig_CancelWaitsForInFlightReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(path, []byte("version: 1\npolicies: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var callsAfterCancel atomic.Uint32
+	var cancelled atomic.Bool
+
+	cancelFn, err := WatchConfig(path, func(*PastaayConfig) {
+		if cancelled.Load() {
+			callsAfterCancel.Add(1)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger a reload, then cancel during the debounce window.
+	_ = os.WriteFile(path, []byte("version: 1\npolicies: []\n"), 0o600)
+	time.Sleep(20 * time.Millisecond)
+	cancelled.Store(true)
+	cancelFn()
+
+	time.Sleep(debounceWindow + 200*time.Millisecond)
+	if got := callsAfterCancel.Load(); got != 0 {
+		t.Fatalf("reloadCallback fired %d time(s) after cancel — use-after-cancel hazard", got)
+	}
+}
+
+func TestManager_NoTornReadsUnderRapidUpdates(t *testing.T) {
+	mgr := NewManager(&PastaayConfig{Version: 1})
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	// writer
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			i++
+			mgr.Update(&PastaayConfig{
+				Version: 1,
+				Policies: []Policy{
+					{Type: "http", Target: "/x"},
+					{Type: "sql", Target: "all"},
+				},
+			})
+		}
+	}()
+	// readers
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				_ = mgr.GetActivePolicies("http")
+				_ = mgr.GetActivePolicies("sql")
+				_ = mgr.GetRawConfig()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -49,7 +49,7 @@ func (m *Manager) GetSensorStatuses() map[string]string {
 	return res
 }
 
-// canonicalFloat64Bits canonicalizes negative zero and NaN so two configs
+// canonicalFloat64Bits collapses ±0 and NaN.
 func canonicalFloat64Bits(v float64) uint64 {
 	if math.IsNaN(v) {
 		return 0x7FF8000000000001 // canonical quiet NaN
@@ -248,6 +248,9 @@ func (m *Manager) IsCleanCommandIgnored(protocol string, cleanCmd string) bool {
 		if list, ok := DefaultProtectedCommands[protocol]; ok {
 			for _, protected := range list {
 				p := strings.TrimLeft(strings.ToUpper(protected), "/")
+				if p == "" {
+					continue
+				}
 				if strings.HasPrefix(cleanCmd, p) {
 					return true
 				}
@@ -258,6 +261,9 @@ func (m *Manager) IsCleanCommandIgnored(protocol string, cleanCmd string) bool {
 		if customList, ok := cfg.IgnoredCommands[protocol]; ok {
 			for _, custom := range customList {
 				c := strings.TrimLeft(strings.ToUpper(custom), "/")
+				if c == "" {
+					continue
+				}
 				if strings.HasPrefix(cleanCmd, c) {
 					return true
 				}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -111,6 +111,12 @@ func (m *Manager) Update(newCfg *PastaayConfig) {
 			}
 			p.MetricTag = tag
 
+			// Wildcard detection
+			if strings.HasSuffix(p.Target, "*") && len(p.Target) > 1 {
+				p.IsWildcard = true
+				p.WildcardPrefix = strings.ToUpper(p.Target[:len(p.Target)-1])
+			}
+
 			// SQL Smart Boundary & Regex
 			if strings.EqualFold(p.Type, "sql") && !strings.EqualFold(p.Target, "ALL") && !strings.EqualFold(p.Target, "DATABASE") {
 				targetPattern := p.Target
@@ -140,7 +146,8 @@ func (m *Manager) Update(newCfg *PastaayConfig) {
 	cache := make(map[string][]Policy)
 	if newCfg != nil {
 		for _, p := range newCfg.Policies {
-			cache[p.Type] = append(cache[p.Type], p)
+			key := strings.ToLower(p.Type)
+			cache[key] = append(cache[key], p)
 		}
 	}
 	m.typedPolicies.Store(&cache)
@@ -152,7 +159,7 @@ func (m *Manager) GetActivePolicies(policyType string) []Policy {
 	if ptr == nil || (cfg != nil && time.Since(m.startTime) < cfg.WarmupDuration) {
 		return nil
 	}
-	return (*ptr)[policyType]
+	return (*ptr)[strings.ToLower(policyType)]
 }
 
 func CleanSQLCommand(cmd string) string {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log"
 	"math"
 	"regexp"
 	"sort"
@@ -10,18 +11,23 @@ import (
 	"time"
 )
 
+// unit of atomic publication
+type snapshot struct {
+	cfg           *PastaayConfig
+	typedPolicies map[string][]Policy
+}
+
 type Manager struct {
-	mu            sync.Mutex
-	cfg           atomic.Pointer[PastaayConfig]
-	typedPolicies atomic.Pointer[map[string][]Policy]
-	startTime     time.Time
-	sensorStatus  sync.Map // map[string]string
+	mu           sync.Mutex
+	snap         atomic.Pointer[snapshot]
+	startTime    time.Time
+	sensorStatus sync.Map // map[string]string
 }
 
 func NewManager(initialConfig *PastaayConfig) *Manager {
 	m := &Manager{startTime: time.Now()}
-	emptyMap := make(map[string][]Policy)
-	m.typedPolicies.Store(&emptyMap)
+	// Seed with empty snapshot so readers never observe a nil snap.
+	m.snap.Store(&snapshot{typedPolicies: make(map[string][]Policy)})
 	m.Update(initialConfig)
 	return m
 }
@@ -33,45 +39,59 @@ func (m *Manager) SetSensorStatus(name, status string) {
 func (m *Manager) GetSensorStatuses() map[string]string {
 	res := make(map[string]string)
 	m.sensorStatus.Range(func(k, v interface{}) bool {
-		res[k.(string)] = v.(string)
+		ks, kok := k.(string)
+		vs, vok := v.(string)
+		if kok && vok {
+			res[ks] = vs
+		}
 		return true
 	})
 	return res
 }
 
+// canonicalFloat64Bits canonicalizes negative zero and NaN so two configs
+func canonicalFloat64Bits(v float64) uint64 {
+	if math.IsNaN(v) {
+		return 0x7FF8000000000001 // canonical quiet NaN
+	}
+	if v == 0 {
+		return 0 // collapse +0 and -0
+	}
+	return math.Float64bits(v)
+}
+
 func generateStableHash(p *Policy) uint64 {
+	const prime uint64 = 1099511628211
 	var h uint64 = 14695981039346656037
-	sep := func() { h ^= 0; h *= 1099511628211 }
+	sep := func() { h *= prime }
 
 	for _, s := range []string{p.Name, p.Target, p.Type, p.ErrorBody, p.StreamRollMode} {
 		for i := 0; i < len(s); i++ {
 			h ^= uint64(s[i])
-			h *= 1099511628211
+			h *= prime
 		}
 		sep()
 	}
 
 	if p.DropConnection {
 		h ^= 1
-	} else {
-		h ^= 0
 	}
-	h *= 1099511628211
+	h *= prime
 
 	h ^= uint64(p.ThrottleThreshold)
-	h *= 1099511628211
+	h *= prime
 	h ^= uint64(p.RAMChunkMB)
-	h *= 1099511628211
+	h *= prime
 	h ^= uint64(p.RAMInterval)
-	h *= 1099511628211
+	h *= prime
 	h ^= uint64(p.LatencyDuration)
-	h *= 1099511628211
+	h *= prime
 	h ^= uint64(p.ErrorCode)
-	h *= 1099511628211
-	h ^= math.Float64bits(p.LatencyChance)
-	h *= 1099511628211
-	h ^= math.Float64bits(p.ErrorChance)
-	h *= 1099511628211
+	h *= prime
+	h ^= canonicalFloat64Bits(p.LatencyChance)
+	h *= prime
+	h ^= canonicalFloat64Bits(p.ErrorChance)
+	h *= prime
 
 	if len(p.MatchHeaders) > 0 {
 		keys := make([]string, 0, len(p.MatchHeaders))
@@ -83,12 +103,12 @@ func generateStableHash(p *Policy) uint64 {
 			v := p.MatchHeaders[k]
 			for i := 0; i < len(k); i++ {
 				h ^= uint64(k[i])
-				h *= 1099511628211
+				h *= prime
 			}
 			sep()
 			for i := 0; i < len(v); i++ {
 				h ^= uint64(v[i])
-				h *= 1099511628211
+				h *= prime
 			}
 			sep()
 		}
@@ -96,13 +116,20 @@ func generateStableHash(p *Policy) uint64 {
 	return h
 }
 
+// Update atomically swaps in a new configuration.
 func (m *Manager) Update(newCfg *PastaayConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	newSnap := &snapshot{typedPolicies: make(map[string][]Policy)}
+
 	if newCfg != nil {
+		if err := newCfg.Validate(); err != nil {
+			log.Printf("[Pastaay-Config] Update rejected: %v", err)
+			return
+		}
 
 		for i := range newCfg.Policies {
-
 			p := &newCfg.Policies[i]
 
 			tag := p.Type + ":" + p.Target
@@ -111,13 +138,11 @@ func (m *Manager) Update(newCfg *PastaayConfig) {
 			}
 			p.MetricTag = tag
 
-			// Wildcard detection
 			if strings.HasSuffix(p.Target, "*") && len(p.Target) > 1 {
 				p.IsWildcard = true
 				p.WildcardPrefix = strings.ToUpper(p.Target[:len(p.Target)-1])
 			}
 
-			// SQL Smart Boundary & Regex
 			if strings.EqualFold(p.Type, "sql") && !strings.EqualFold(p.Target, "ALL") && !strings.EqualFold(p.Target, "DATABASE") {
 				targetPattern := p.Target
 
@@ -133,40 +158,45 @@ func (m *Manager) Update(newCfg *PastaayConfig) {
 				}
 
 				re, err := regexp.Compile(`(?i)` + targetPattern)
-				if err == nil {
+				if err != nil {
+					log.Printf("[Pastaay-Config] WARN: policy %q target regex compile failed: %v", p.Name, err)
+				} else {
 					p.CompiledRegex = re
 				}
 			}
 
 			p.PolicyHash = generateStableHash(p)
 		}
-		m.cfg.Store(newCfg)
 
-	}
-	cache := make(map[string][]Policy)
-	if newCfg != nil {
+		newSnap.cfg = newCfg
 		for _, p := range newCfg.Policies {
 			key := strings.ToLower(p.Type)
-			cache[key] = append(cache[key], p)
+			newSnap.typedPolicies[key] = append(newSnap.typedPolicies[key], p)
 		}
 	}
-	m.typedPolicies.Store(&cache)
+
+	// Single atomic publication
+	m.snap.Store(newSnap)
 }
 
 func (m *Manager) GetActivePolicies(policyType string) []Policy {
-	ptr := m.typedPolicies.Load()
-	cfg := m.cfg.Load()
-	if ptr == nil || (cfg != nil && time.Since(m.startTime) < cfg.WarmupDuration) {
+	s := m.snap.Load()
+	if s == nil {
 		return nil
 	}
-	return (*ptr)[strings.ToLower(policyType)]
+	if s.cfg != nil && s.cfg.WarmupDuration > 0 && time.Since(m.startTime) < s.cfg.WarmupDuration {
+		return nil
+	}
+	return s.typedPolicies[strings.ToLower(policyType)]
 }
 
+// CleanSQLCommand strips comments and uppercases for matching.
 func CleanSQLCommand(cmd string) string {
 	if cmd == "" {
 		return ""
 	}
 	var result strings.Builder
+	result.Grow(len(cmd))
 	inString := false
 	var stringChar byte
 	for i := 0; i < len(cmd); i++ {
@@ -209,14 +239,14 @@ func CleanSQLCommand(cmd string) string {
 }
 
 func (m *Manager) IsCleanCommandIgnored(protocol string, cleanCmd string) bool {
-	cfg := m.cfg.Load()
-	if cfg == nil {
+	s := m.snap.Load()
+	if s == nil || s.cfg == nil {
 		return false
 	}
+	cfg := s.cfg
 	if cfg.EnableDefaultIgnored {
 		if list, ok := DefaultProtectedCommands[protocol]; ok {
 			for _, protected := range list {
-
 				p := strings.TrimLeft(strings.ToUpper(protected), "/")
 				if strings.HasPrefix(cleanCmd, p) {
 					return true
@@ -227,7 +257,6 @@ func (m *Manager) IsCleanCommandIgnored(protocol string, cleanCmd string) bool {
 	if cfg.IgnoredCommands != nil {
 		if customList, ok := cfg.IgnoredCommands[protocol]; ok {
 			for _, custom := range customList {
-
 				c := strings.TrimLeft(strings.ToUpper(custom), "/")
 				if strings.HasPrefix(cleanCmd, c) {
 					return true
@@ -248,5 +277,9 @@ func (m *Manager) IsCommandIgnored(protocol string, cmd string) bool {
 }
 
 func (m *Manager) GetRawConfig() *PastaayConfig {
-	return m.cfg.Load()
+	s := m.snap.Load()
+	if s == nil {
+		return nil
+	}
+	return s.cfg
 }

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -1,14 +1,26 @@
 package config
 
 import (
+	"fmt"
 	"log"
 	"os"
 
 	"gopkg.in/yaml.v3"
 )
 
+// maxConfigFileBytes protects against OOM from a hostile/accidental gigabyte config file.
+const maxConfigFileBytes = 5 << 20 // 5 MiB
+
 // LoadConfig reads and parses the YAML configuration file from the given path.
 func LoadConfig(filePath string) (*PastaayConfig, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() > maxConfigFileBytes {
+		return nil, fmt.Errorf("config file %s is %d bytes — exceeds limit of %d", filePath, fi.Size(), maxConfigFileBytes)
+	}
+
 	file, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -12,17 +13,18 @@ const maxConfigFileBytes = 5 << 20 // 5 MiB
 
 // LoadConfig reads, sanitizes, and validates the YAML configuration file.
 func LoadConfig(filePath string) (*PastaayConfig, error) {
-	fi, err := os.Stat(filePath)
+	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
-	if fi.Size() > maxConfigFileBytes {
-		return nil, fmt.Errorf("config file %s is %d bytes — exceeds limit of %d", filePath, fi.Size(), maxConfigFileBytes)
-	}
+	defer f.Close()
 
-	file, err := os.ReadFile(filePath)
+	file, err := io.ReadAll(io.LimitReader(f, maxConfigFileBytes+1))
 	if err != nil {
 		return nil, err
+	}
+	if int64(len(file)) > maxConfigFileBytes {
+		return nil, fmt.Errorf("config file %s exceeds %d byte ceiling", filePath, maxConfigFileBytes)
 	}
 
 	if hasSuspiciousYAMLAlias(file) {

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -11,7 +10,7 @@ import (
 // maxConfigFileBytes protects against OOM from a hostile/accidental gigabyte config file.
 const maxConfigFileBytes = 5 << 20 // 5 MiB
 
-// LoadConfig reads and parses the YAML configuration file from the given path.
+// LoadConfig reads, sanitizes, and validates the YAML configuration file.
 func LoadConfig(filePath string) (*PastaayConfig, error) {
 	fi, err := os.Stat(filePath)
 	if err != nil {
@@ -26,16 +25,18 @@ func LoadConfig(filePath string) (*PastaayConfig, error) {
 		return nil, err
 	}
 
+	if hasSuspiciousYAMLAlias(file) {
+		return nil, fmt.Errorf("config file %s: YAML aliases are not permitted (potential alias-bomb)", filePath)
+	}
+
 	var cfg PastaayConfig
 	if err := yaml.Unmarshal(file, &cfg); err != nil {
 		return nil, err
 	}
 
-	return &cfg, nil
-}
-
-func decodeOrWarn(p *Policy, field string, node yaml.Node, dst interface{}) {
-	if err := node.Decode(dst); err != nil {
-		log.Printf("[WARN] policy %q: %s decode error: %v", p.Name, field, err)
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("config %s validation: %w", filePath, err)
 	}
+
+	return &cfg, nil
 }

--- a/pkg/config/remote_k8s.go
+++ b/pkg/config/remote_k8s.go
@@ -33,6 +33,9 @@ type k8sConfigMap struct {
 
 // WatchK8sConfigMap polls K8s API and reports health status to the Manager.
 func WatchK8sConfigMap(ctx context.Context, cmName, cmKey string, interval time.Duration, mgr *Manager) error {
+	if interval < time.Second {
+		interval = time.Second
+	}
 
 	_, err := os.ReadFile(k8sTokenPath)
 	if err != nil {
@@ -109,7 +112,7 @@ func WatchK8sConfigMap(ctx context.Context, cmName, cmKey string, interval time.
 				}
 
 				if resp.StatusCode != http.StatusOK {
-					io.Copy(io.Discard, resp.Body)
+					_, _ = io.Copy(io.Discard, resp.Body)
 					resp.Body.Close()
 					mgr.SetSensorStatus("k8s", fmt.Sprintf("http_%d", resp.StatusCode))
 					continue

--- a/pkg/config/watcher.go
+++ b/pkg/config/watcher.go
@@ -1,78 +1,102 @@
 package config
 
 import (
+	"context"
 	"log"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
 
-func WatchConfig(filePath string, reloadCallback func(*PastaayConfig)) error {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return err
+const debounceWindow = 300 * time.Millisecond
+
+// WatchConfig watches filePath and invokes reloadCallback on each successful reload.
+func WatchConfig(filePath string, reloadCallback func(*PastaayConfig)) (cancel func(), err error) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	watcher, werr := fsnotify.NewWatcher()
+	if werr != nil {
+		cancelCtx()
+		return nil, werr
+	}
+	if aerr := watcher.Add(filePath); aerr != nil {
+		_ = watcher.Close()
+		cancelCtx()
+		return nil, aerr
 	}
 
 	var (
-		timer         *time.Timer
-		timerMu       sync.Mutex
-		isReattaching atomic.Bool
+		timer   *time.Timer
+		timerMu sync.Mutex
 	)
 
+	// scheduleReload coalesces every kind of event onto the debounce window.
+	scheduleReload := func(reason string) {
+		timerMu.Lock()
+		defer timerMu.Unlock()
+		if timer != nil {
+			timer.Stop()
+		}
+		timer = time.AfterFunc(debounceWindow, func() {
+
+			_ = watcher.Remove(filePath)
+			for attempt := 0; attempt < 10; attempt++ {
+				if err := watcher.Add(filePath); err == nil {
+					break
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			newCfg, loadErr := LoadConfig(filePath)
+			if loadErr != nil {
+				log.Printf("[Pastaay-Config] reload skipped (%s): %v", reason, loadErr)
+				return
+			}
+			if vErr := newCfg.Validate(); vErr != nil {
+				log.Printf("[Pastaay-Config] reload rejected (%s): %v", reason, vErr)
+				return
+			}
+			reloadCallback(newCfg)
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer watcher.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case event, ok := <-watcher.Events:
 				if !ok {
 					return
 				}
-
-				if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) || event.Has(fsnotify.Chmod) {
-					if isReattaching.CompareAndSwap(false, true) {
-						go func(op fsnotify.Op) {
-							defer isReattaching.Store(false)
-							log.Printf("Pastaay: Config inode changed [%s]. Attempting re-attach...", op)
-							for i := 0; i < 10; i++ {
-								time.Sleep(500 * time.Millisecond)
-								if err := watcher.Add(filePath); err == nil {
-									if newCfg, loadErr := LoadConfig(filePath); loadErr == nil {
-										reloadCallback(newCfg)
-										log.Println("Pastaay: Watcher re-attached successfully.")
-										return
-									}
-								}
-							}
-							log.Printf("Pastaay: Failed to re-attach watcher to %s after 10 attempts.", filePath)
-						}(event.Op)
-					}
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) ||
+					event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) ||
+					event.Has(fsnotify.Chmod) {
+					scheduleReload(event.Op.String())
 				}
-
-				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-					timerMu.Lock()
-					if timer != nil {
-						timer.Stop()
-					}
-					timer = time.AfterFunc(300*time.Millisecond, func() {
-						newCfg, loadErr := LoadConfig(filePath)
-						if loadErr != nil {
-							log.Printf("Pastaay: Hot-reload skipped. Invalid configuration: %v", loadErr)
-							return
-						}
-						reloadCallback(newCfg)
-					})
-					timerMu.Unlock()
-				}
-
-			case err, ok := <-watcher.Errors:
+			case errEv, ok := <-watcher.Errors:
 				if !ok {
 					return
 				}
-				log.Printf("Pastaay: Watcher runtime error: %v", err)
+				log.Printf("[Pastaay-Config] watcher error (forcing reattach): %v", errEv)
+				scheduleReload("watcher-error")
 			}
 		}
 	}()
-	return watcher.Add(filePath)
+
+	cancel = func() {
+		cancelCtx()
+		// Stop any pending debounce timer to avoid spurious post-cancel reloads.
+		timerMu.Lock()
+		if timer != nil {
+			timer.Stop()
+		}
+		timerMu.Unlock()
+		wg.Wait()
+	}
+	return cancel, nil
 }

--- a/pkg/config/watcher.go
+++ b/pkg/config/watcher.go
@@ -26,25 +26,43 @@ func WatchConfig(filePath string, reloadCallback func(*PastaayConfig)) (cancel f
 	}
 
 	var (
-		timer   *time.Timer
-		timerMu sync.Mutex
+		timer    *time.Timer
+		timerMu  sync.Mutex
+		fireWG   sync.WaitGroup // tracks in-flight debounced reload bodies
+		stopFlag = make(chan struct{})
 	)
 
-	// scheduleReload coalesces every kind of event onto the debounce window.
 	scheduleReload := func(reason string) {
 		timerMu.Lock()
 		defer timerMu.Unlock()
+		select {
+		case <-stopFlag:
+			return
+		default:
+		}
 		if timer != nil {
 			timer.Stop()
 		}
 		timer = time.AfterFunc(debounceWindow, func() {
+			fireWG.Add(1)
+			defer fireWG.Done()
+			// Re-check stop flag
+			select {
+			case <-stopFlag:
+				return
+			default:
+			}
 
 			_ = watcher.Remove(filePath)
 			for attempt := 0; attempt < 10; attempt++ {
 				if err := watcher.Add(filePath); err == nil {
 					break
 				}
-				time.Sleep(50 * time.Millisecond)
+				select {
+				case <-stopFlag:
+					return
+				case <-time.After(50 * time.Millisecond):
+				}
 			}
 
 			newCfg, loadErr := LoadConfig(filePath)
@@ -56,14 +74,19 @@ func WatchConfig(filePath string, reloadCallback func(*PastaayConfig)) (cancel f
 				log.Printf("[Pastaay-Config] reload rejected (%s): %v", reason, vErr)
 				return
 			}
+			select {
+			case <-stopFlag:
+				return
+			default:
+			}
 			reloadCallback(newCfg)
 		})
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	var loopWG sync.WaitGroup
+	loopWG.Add(1)
 	go func() {
-		defer wg.Done()
+		defer loopWG.Done()
 		defer watcher.Close()
 		for {
 			select {
@@ -89,14 +112,15 @@ func WatchConfig(filePath string, reloadCallback func(*PastaayConfig)) (cancel f
 	}()
 
 	cancel = func() {
+		close(stopFlag)
 		cancelCtx()
-		// Stop any pending debounce timer to avoid spurious post-cancel reloads.
 		timerMu.Lock()
 		if timer != nil {
 			timer.Stop()
 		}
 		timerMu.Unlock()
-		wg.Wait()
+		loopWG.Wait()
+		fireWG.Wait()
 	}
 	return cancel, nil
 }

--- a/pkg/config/webhook.go
+++ b/pkg/config/webhook.go
@@ -6,9 +6,16 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+func mustCompileMulti(pattern string) *regexp.Regexp {
+	return regexp.MustCompile("(?m)" + pattern)
+}
 
 const maxWebhookPayloadBytes = 1 << 20 // 1MB Safety Cap
 
@@ -19,7 +26,9 @@ type WebhookResponse struct {
 }
 
 // WebhookHandler provides a memory-bounded, constant-time authenticated endpoint.
+// Empty expectedToken refuses requests unless PASTAAY_DEV_ALLOW_NO_TOKEN=1.
 func WebhookHandler(expectedToken string, reloadCallback func(*PastaayConfig)) http.HandlerFunc {
+	devAllow := os.Getenv("PASTAAY_DEV_ALLOW_NO_TOKEN") == "1"
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -30,17 +39,32 @@ func WebhookHandler(expectedToken string, reloadCallback func(*PastaayConfig)) h
 
 		defer r.Body.Close()
 
-		// Timing-attack resistant token validation.
-		reqToken := r.Header.Get("X-Pastaay-Token")
-		if expectedToken != "" && subtle.ConstantTimeCompare([]byte(reqToken), []byte(expectedToken)) != 1 {
-			log.Printf("[Pastaay-Webhook] Blocked unauthorized request from %s", r.RemoteAddr)
-			writeJSONError(w, http.StatusUnauthorized, "Invalid token", "")
-			return
+		// Auth gate — fail-closed by default.
+		if expectedToken == "" {
+			if !devAllow {
+				writeJSONError(w, http.StatusServiceUnavailable, "engine token not configured", "")
+				return
+			}
+			log.Printf("[Pastaay-Webhook] DEV: unauthenticated %s from %s", r.URL.Path, r.RemoteAddr)
+		} else {
+			reqToken := r.Header.Get("X-Pastaay-Token")
+			if subtle.ConstantTimeCompare([]byte(reqToken), []byte(expectedToken)) != 1 {
+				log.Printf("[Pastaay-Webhook] Blocked unauthorized request from %s", r.RemoteAddr)
+				writeJSONError(w, http.StatusUnauthorized, "Invalid token", "")
+				return
+			}
 		}
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, maxWebhookPayloadBytes))
 		if err != nil {
 			writeJSONError(w, http.StatusBadRequest, "Payload read error or too large", "")
+			return
+		}
+
+		// Reject YAML alias bombs before they reach the parser. yaml.v3 does
+		// not enforce alias-expansion limits.
+		if hasSuspiciousYAMLAlias(body) {
+			writeJSONError(w, http.StatusBadRequest, "YAML aliases are not permitted", "")
 			return
 		}
 
@@ -64,6 +88,51 @@ func WebhookHandler(expectedToken string, reloadCallback func(*PastaayConfig)) h
 		}
 	}
 }
+
+// hasSuspiciousYAMLAlias is a conservative pre-filter against billion-laughs (alias-bomb) DoS.
+func hasSuspiciousYAMLAlias(body []byte) bool {
+	s := stripYAMLStringLiterals(string(body))
+	return reYAMLAnchor.MatchString(s) && reYAMLAlias.MatchString(s)
+}
+
+// stripYAMLStringLiterals removes single/double-quoted regions so that values
+func stripYAMLStringLiterals(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c == '\'' || c == '"' {
+			quote := c
+			i++
+
+			for i < len(s) && s[i] != quote {
+				if quote == '"' && s[i] == '\\' && i+1 < len(s) {
+					i += 2
+					continue
+				}
+				i++
+			}
+			if i < len(s) {
+				i++ // consume closing quote
+			}
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+// reYAMLAnchor matches an anchor declaration "&name" appearing after any of:
+// start-of-line, colon-space, dash-space, comma, opening bracket, or opening
+// brace. This covers block and flow styles.
+var reYAMLAnchor = mustCompileMulti(`(^|[\s\:\,\-\[\{])&[A-Za-z0-9_\-]+`)
+
+// reYAMLAlias matches an alias reference "*name" appearing in the same
+// positions. Crucially this catches flow-style bombs like `[*a,*a,*a]`.
+var reYAMLAlias = mustCompileMulti(`(^|[\s\:\,\-\[\{])\*[A-Za-z0-9_\-]+`)
 
 func writeJSONError(w http.ResponseWriter, code int, msg, details string) {
 	w.WriteHeader(code)

--- a/pkg/config/webhook.go
+++ b/pkg/config/webhook.go
@@ -25,8 +25,7 @@ type WebhookResponse struct {
 	Details string `json:"details,omitempty"`
 }
 
-// WebhookHandler provides a memory-bounded, constant-time authenticated endpoint.
-// Empty expectedToken refuses requests unless PASTAAY_DEV_ALLOW_NO_TOKEN=1.
+// WebhookHandler validates and stores config with auth + size limits.
 func WebhookHandler(expectedToken string, reloadCallback func(*PastaayConfig)) http.HandlerFunc {
 	devAllow := os.Getenv("PASTAAY_DEV_ALLOW_NO_TOKEN") == "1"
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -89,13 +88,13 @@ func WebhookHandler(expectedToken string, reloadCallback func(*PastaayConfig)) h
 	}
 }
 
-// hasSuspiciousYAMLAlias is a conservative pre-filter against billion-laughs (alias-bomb) DoS.
+// hasSuspiciousYAMLAlias detects YAML alias-bomb patterns.
 func hasSuspiciousYAMLAlias(body []byte) bool {
 	s := stripYAMLStringLiterals(string(body))
 	return reYAMLAnchor.MatchString(s) && reYAMLAlias.MatchString(s)
 }
 
-// stripYAMLStringLiterals removes single/double-quoted regions so that values
+// stripYAMLStringLiterals removes quoted regions to avoid false positives.
 func stripYAMLStringLiterals(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))

--- a/pkg/grpcchaos/interceptor.go
+++ b/pkg/grpcchaos/interceptor.go
@@ -30,7 +30,7 @@ type chaosServerStream struct {
 	method          string
 	cfgManager      *config.Manager
 	mu              sync.Mutex
-	decidedPolicies map[string]PolicyDecision
+	decidedPolicies map[uint64]PolicyDecision // keyed by PolicyHash (Name is not unique)
 	isIgnored       bool
 	incomingMD      metadata.MD
 }
@@ -58,7 +58,7 @@ func (s *chaosServerStream) evaluate(ctx context.Context, next func() error) err
 
 			if isStreamMode && s.decidedPolicies != nil {
 				s.mu.Lock()
-				d, decided := s.decidedPolicies[p.Name]
+				d, decided := s.decidedPolicies[p.PolicyHash]
 
 				if decided && d.Hash == p.PolicyHash {
 					s.mu.Unlock()
@@ -82,21 +82,31 @@ func (s *chaosServerStream) evaluate(ctx context.Context, next func() error) err
 					continue
 				}
 
-				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
+				latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+				errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+				if latencyHit && errorHit {
+					latencyHit = false
+				}
+				if latencyHit {
 					decision.Latency = p.LatencyDuration
 				}
-				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
+				if errorHit {
 					decision.Err = generateError(p)
 				}
 				decision.Hash = p.PolicyHash
 
-				s.decidedPolicies[p.Name] = decision
+				s.decidedPolicies[p.PolicyHash] = decision
 				s.mu.Unlock()
 			} else {
-				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
+				latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+				errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+				if latencyHit && errorHit {
+					latencyHit = false
+				}
+				if latencyHit {
 					decision.Latency = p.LatencyDuration
 				}
-				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
+				if errorHit {
 					decision.Err = generateError(p)
 				}
 			}
@@ -202,7 +212,7 @@ func StreamInterceptor(mgr *config.Manager) grpc.StreamServerInterceptor {
 			ServerStream:    ss,
 			method:          info.FullMethod,
 			cfgManager:      mgr,
-			decidedPolicies: make(map[string]PolicyDecision),
+			decidedPolicies: make(map[uint64]PolicyDecision),
 			isIgnored:       mgr.IsCommandIgnored("grpc", info.FullMethod),
 			incomingMD:      md,
 		}

--- a/pkg/grpcchaos/interceptor.go
+++ b/pkg/grpcchaos/interceptor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/CemAkan/pastaay/pkg/tracing"
 )
 
+// PolicyDecision captures the chaos outcome for a particular gRPC method"'s policy match.
 type PolicyDecision struct {
 	Latency time.Duration
 	Err     error

--- a/pkg/grpcchaos/interceptor_test.go
+++ b/pkg/grpcchaos/interceptor_test.go
@@ -108,3 +108,26 @@ func TestGenerateError(t *testing.T) {
 		t.Errorf("Custom error generation failed: %v", err2)
 	}
 }
+func TestStreamCache_KeyedByHashNotName(t *testing.T) {
+	a := config.Policy{Name: "duo", Type: "grpc", Target: "all", LatencyChance: 1.0, ErrorChance: 0, StreamRollMode: "stream"}
+	b := config.Policy{Name: "duo", Type: "grpc", Target: "all", LatencyChance: 0, ErrorChance: 1.0, StreamRollMode: "stream"}
+
+	mgr := config.NewManager(&config.PastaayConfig{
+		Version:  1,
+		Policies: []config.Policy{a, b},
+	})
+	got := mgr.GetActivePolicies("grpc")
+	if len(got) != 2 {
+		t.Fatalf("expected both policies to survive Update, got %d", len(got))
+	}
+	if got[0].PolicyHash == got[1].PolicyHash {
+		t.Fatalf("policies with different rolls must have different PolicyHash; got %x", got[0].PolicyHash)
+	}
+	//keyed by hash, both policies fit.
+	cache := make(map[uint64]PolicyDecision)
+	cache[got[0].PolicyHash] = PolicyDecision{Hash: got[0].PolicyHash}
+	cache[got[1].PolicyHash] = PolicyDecision{Hash: got[1].PolicyHash}
+	if len(cache) != 2 {
+		t.Fatalf("hash-keyed cache must hold both same-named policies, got %d", len(cache))
+	}
+}

--- a/pkg/guard/guard.go
+++ b/pkg/guard/guard.go
@@ -3,6 +3,7 @@ package guard
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/CemAkan/pastaay/pkg/config"
@@ -37,12 +38,12 @@ func Analyze(cfg *config.PastaayConfig) PlanResult {
 		}
 
 		scopeWeight := 0.4
-		if p.Target == "all" || p.Target == "database" || p.Target == "*" || p.Target == "" {
+		if strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, "database") || p.Target == "*" || p.Target == "" {
 			scopeWeight = 1.0
 			res.Issues = append(res.Issues, fmt.Sprintf("[%s] Global Target: Exposes entire '%s' infrastructure layer.", p.Name, p.Type))
 		}
 
-		key := p.Type + ":" + p.Target
+		key := strings.ToLower(p.Type) + ":" + strings.ToLower(p.Target)
 		if orig, exists := targets[key]; exists {
 			res.Issues = append(res.Issues, fmt.Sprintf("[%s] Collision: Overlaps with '%s'. Cascading failure probability increased.", p.Name, orig))
 			scopeWeight = math.Min(1.0, scopeWeight+0.2)
@@ -94,6 +95,10 @@ func Analyze(cfg *config.PastaayConfig) PlanResult {
 		}
 
 		policyRisk := maxSeverity * scopeWeight
+
+		if policyRisk > 0.95 {
+			policyRisk = 0.95
+		}
 		systemSurvival *= (1.0 - policyRisk)
 	}
 

--- a/pkg/guard/guard_test.go
+++ b/pkg/guard/guard_test.go
@@ -1,0 +1,124 @@
+package guard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/CemAkan/pastaay/pkg/config"
+)
+
+func TestAnalyze_NilOrEmptyConfigIsSafe(t *testing.T) {
+	if got := Analyze(nil); got.Status != "SAFE" {
+		t.Errorf("nil config should yield SAFE, got %s", got.Status)
+	}
+	if got := Analyze(&config.PastaayConfig{}); got.Status != "SAFE" {
+		t.Errorf("empty config should yield SAFE, got %s", got.Status)
+	}
+}
+
+func TestAnalyze_ScoreScalesWithSeverity(t *testing.T) {
+	low := Analyze(&config.PastaayConfig{
+		EnableDefaultIgnored: true,
+		Policies: []config.Policy{
+			{Name: "tiny", Type: "http", Target: "/a", ErrorChance: 0.05},
+		},
+	})
+	high := Analyze(&config.PastaayConfig{
+		EnableDefaultIgnored: true,
+		Policies: []config.Policy{
+			{Name: "global-kill", Type: "http", Target: "all", ErrorChance: 1.0, DropConnection: true},
+		},
+	})
+	if low.Score >= high.Score {
+		t.Fatalf("low(%d) must be < high(%d)", low.Score, high.Score)
+	}
+}
+
+func TestAnalyze_ScoreBoundedAndCritical(t *testing.T) {
+	pols := make([]config.Policy, 0, 50)
+	for i := 0; i < 50; i++ {
+		pols = append(pols, config.Policy{
+			Name: "p", Type: "http", Target: "all", ErrorChance: 1.0, DropConnection: true,
+		})
+	}
+	res := Analyze(&config.PastaayConfig{EnableDefaultIgnored: true, Policies: pols})
+	if res.Score < 0 || res.Score > 100 {
+		t.Fatalf("Score out of bounds: %d", res.Score)
+	}
+	if res.Status != "CRITICAL" {
+		t.Fatalf("expected CRITICAL status, got %s", res.Status)
+	}
+}
+
+func TestAnalyze_5sLatencyTriggersThreadPoolWarning(t *testing.T) {
+	res := Analyze(&config.PastaayConfig{
+		EnableDefaultIgnored: true,
+		Policies: []config.Policy{
+			{Name: "slow", Type: "http", Target: "/", LatencyChance: 0.5, LatencyDuration: 6 * time.Second},
+		},
+	})
+	found := false
+	for _, msg := range res.Issues {
+		if containsAll(msg, []string{"slow", "thread-pool"}) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("5s latency policy must surface thread-pool warning, got %v", res.Issues)
+	}
+}
+
+func TestAnalyze_ResourceOOMWarning(t *testing.T) {
+	res := Analyze(&config.PastaayConfig{
+		EnableDefaultIgnored: true,
+		Policies: []config.Policy{
+			{Name: "oom", Type: "resource", Target: "host", RAMChunkMB: 2048},
+		},
+	})
+	found := false
+	for _, m := range res.Issues {
+		if containsAll(m, []string{"OOM"}) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("RAMChunkMB>=1024 must trigger OOM Risk warning, got %v", res.Issues)
+	}
+}
+
+func TestAnalyze_CollisionDetected(t *testing.T) {
+	res := Analyze(&config.PastaayConfig{
+		EnableDefaultIgnored: true,
+		Policies: []config.Policy{
+			{Name: "p1", Type: "http", Target: "all", ErrorChance: 0.5},
+			{Name: "p2", Type: "http", Target: "all", LatencyChance: 0.5, LatencyDuration: time.Second},
+		},
+	})
+	found := false
+	for _, m := range res.Issues {
+		if containsAll(m, []string{"Collision"}) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("overlapping policies must flag collision, got %v", res.Issues)
+	}
+}
+
+func containsAll(s string, needles []string) bool {
+	for _, n := range needles {
+		if !contains(s, n) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/guard/handler.go
+++ b/pkg/guard/handler.go
@@ -5,10 +5,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/CemAkan/pastaay/pkg/config"
 	"gopkg.in/yaml.v3"
+)
+
+// reAnchor/reAlias detect YAML anchors and aliases in BOTH block style and flow style
+var (
+	reAnchor = regexp.MustCompile(`(?m)(^|[\s\:\,\-\[\{])&[A-Za-z0-9_\-]+`)
+	reAlias  = regexp.MustCompile(`(?m)(^|[\s\:\,\-\[\{])\*[A-Za-z0-9_\-]+`)
 )
 
 const maxPlanPayloadBytes = 1 << 20
@@ -28,6 +35,11 @@ func PlanFromRequest(r *http.Request) (PlanResult, error) {
 		return PlanResult{}, fmt.Errorf("payload exceeds %d bytes", maxPlanPayloadBytes)
 	}
 
+	// Reject alias bombs prior to decode.
+	if isYAMLLikely(body) && hasAliasMarkers(body) {
+		return PlanResult{}, fmt.Errorf("YAML aliases are not permitted")
+	}
+
 	var cfg config.PastaayConfig
 	ct := strings.ToLower(r.Header.Get("Content-Type"))
 
@@ -42,4 +54,13 @@ func PlanFromRequest(r *http.Request) (PlanResult, error) {
 	}
 
 	return Analyze(&cfg), nil
+}
+
+func isYAMLLikely(body []byte) bool {
+	s := strings.TrimSpace(string(body))
+	return !strings.HasPrefix(s, "{") && !strings.HasPrefix(s, "[")
+}
+
+func hasAliasMarkers(body []byte) bool {
+	return reAnchor.Match(body) && reAlias.Match(body)
 }

--- a/pkg/guard/handler.go
+++ b/pkg/guard/handler.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const maxPlanPayloadBytes = 1 << 20 // 1MB Safety Cap
+const maxPlanPayloadBytes = 1 << 20
 
 func PlanFromRequest(r *http.Request) (PlanResult, error) {
 	if r.Body == nil {
@@ -19,15 +19,18 @@ func PlanFromRequest(r *http.Request) (PlanResult, error) {
 	}
 	defer r.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxPlanPayloadBytes))
+	limited := io.LimitReader(r.Body, maxPlanPayloadBytes+1)
+	body, err := io.ReadAll(limited)
 	if err != nil {
 		return PlanResult{}, err
+	}
+	if int64(len(body)) > maxPlanPayloadBytes {
+		return PlanResult{}, fmt.Errorf("payload exceeds %d bytes", maxPlanPayloadBytes)
 	}
 
 	var cfg config.PastaayConfig
 	ct := strings.ToLower(r.Header.Get("Content-Type"))
 
-	// JSON/YAML switch
 	if strings.Contains(ct, "json") {
 		if err := json.Unmarshal(body, &cfg); err != nil {
 			return PlanResult{}, err

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -18,6 +18,9 @@ func StartServer(ctx context.Context, port string) {
 		Addr:              port,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	go func() {

--- a/pkg/mongochaos/client.go
+++ b/pkg/mongochaos/client.go
@@ -5,7 +5,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-// ApplyChaos integrates Pastaay fault injection into MongoDB ClientOptions.
+// ApplyChaos integrates fault injection into MongoDB ClientOptions.
 func ApplyChaos(opts *options.ClientOptions, mgr *config.Manager) *options.ClientOptions {
 	if opts == nil {
 		opts = options.Client()

--- a/pkg/mongochaos/dialer.go
+++ b/pkg/mongochaos/dialer.go
@@ -13,13 +13,23 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-// ChaosDialer wraps the MongoDB dialer to optionally refuse connections based on active chaos policies.
 type ChaosDialer struct {
 	DefaultDialer options.ContextDialer
 	Manager       *config.Manager
 }
 
+func (c *ChaosDialer) dialFallback(ctx context.Context, network, address string) (net.Conn, error) {
+	if c.DefaultDialer != nil {
+		return c.DefaultDialer.DialContext(ctx, network, address)
+	}
+	fallback := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	return fallback.DialContext(ctx, network, address)
+}
+
 func (c *ChaosDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if c == nil || c.Manager == nil {
+		return c.dialFallback(ctx, network, address)
+	}
 	policies := c.Manager.GetActivePolicies("mongo")
 	for _, p := range policies {
 		if p.DropConnection && (strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, "database")) {
@@ -33,10 +43,5 @@ func (c *ChaosDialer) DialContext(ctx context.Context, network, address string) 
 			}
 		}
 	}
-
-	if c.DefaultDialer != nil {
-		return c.DefaultDialer.DialContext(ctx, network, address)
-	}
-	fallback := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
-	return fallback.DialContext(ctx, network, address)
+	return c.dialFallback(ctx, network, address)
 }

--- a/pkg/mongochaos/dialer.go
+++ b/pkg/mongochaos/dialer.go
@@ -13,6 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
+// ChaosDialer wraps the MongoDB dialer to optionally refuse connections based on active chaos policies.
 type ChaosDialer struct {
 	DefaultDialer options.ContextDialer
 	Manager       *config.Manager

--- a/pkg/mongochaos/monitor.go
+++ b/pkg/mongochaos/monitor.go
@@ -13,6 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/event"
 )
 
+// NewChaosMonitor returns a MongoDB command monitor that evaluates everyn// started command against active Pastaay policies, injecting latency or aborting the command when a policy matches.
 func NewChaosMonitor(mgr *config.Manager) *event.CommandMonitor {
 	return &event.CommandMonitor{
 		Started: func(ctx context.Context, evt *event.CommandStartedEvent) {

--- a/pkg/mongochaos/monitor.go
+++ b/pkg/mongochaos/monitor.go
@@ -13,10 +13,13 @@ import (
 	"go.mongodb.org/mongo-driver/v2/event"
 )
 
-// NewChaosMonitor returns a MongoDB command monitor that evaluates everyn// started command against active Pastaay policies, injecting latency or aborting the command when a policy matches.
+// NewChaosMonitor returns a MongoDB command monitor that applies policies.
 func NewChaosMonitor(mgr *config.Manager) *event.CommandMonitor {
 	return &event.CommandMonitor{
 		Started: func(ctx context.Context, evt *event.CommandStartedEvent) {
+			if mgr == nil || evt == nil {
+				return
+			}
 			if mgr.IsCommandIgnored("mongo", evt.CommandName) {
 				return
 			}
@@ -29,7 +32,13 @@ func NewChaosMonitor(mgr *config.Manager) *event.CommandMonitor {
 
 				metricTag := p.MetricTag
 
-				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
+				latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+				errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+				if latencyHit && errorHit {
+					latencyHit = false
+				}
+
+				if latencyHit {
 					metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "latency").Inc()
 					spanCtx, span := tracing.StartChaosSpan(ctx, "pastaay.mongo.latency", evt.CommandName, "latency")
 
@@ -47,11 +56,15 @@ func NewChaosMonitor(mgr *config.Manager) *event.CommandMonitor {
 					}
 				}
 
-				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
+				if errorHit {
 					metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "error").Inc()
 					_, span := tracing.StartChaosSpan(ctx, "pastaay.mongo.error", evt.CommandName, "error")
 
-					telemetry.EmitError("mongo", evt.CommandName, "Mongo Fault Injected", "force_abort_not_supported", span)
+					msg := p.ErrorBody
+					if msg == "" {
+						msg = "pastaay: synthetic mongo fault (observability-only, driver cannot abort started command)"
+					}
+					telemetry.EmitError("mongo", evt.CommandName, "Mongo Fault Injected", msg, span)
 
 					span.End()
 					return

--- a/pkg/mongochaos/monitor_test.go
+++ b/pkg/mongochaos/monitor_test.go
@@ -9,10 +9,10 @@ import (
 	"go.mongodb.org/mongo-driver/v2/event"
 )
 
-// TestChaosDialer_DropConnection verifies that the dialer correctly drops connections
-// when the DropConnection policy is active.
+// TestChaosDialer_DropConnection verifies that the dialer correctly drops connections when the DropConnection policy is active.
 func TestChaosDialer_DropConnection(t *testing.T) {
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:           "mongo",
@@ -38,11 +38,11 @@ func TestChaosDialer_DropConnection(t *testing.T) {
 	}
 }
 
-// TestChaosMonitor_Latency verifies that the monitor correctly injects
-// the specified sleep duration during command execution.
+// TestChaosMonitor_Latency verifies that the monitor correctly injects the specified sleep duration during command execution.
 func TestChaosMonitor_Latency(t *testing.T) {
 	latency := 100 * time.Millisecond
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:            "mongo",

--- a/pkg/mongochaos/wrap.go
+++ b/pkg/mongochaos/wrap.go
@@ -1,0 +1,95 @@
+package mongochaos
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"strings"
+	"time"
+
+	"github.com/CemAkan/pastaay/pkg/config"
+	"github.com/CemAkan/pastaay/pkg/metrics"
+	"github.com/CemAkan/pastaay/pkg/telemetry"
+	"github.com/CemAkan/pastaay/pkg/tracing"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+type WrappedClient struct {
+	*mongo.Client
+	mgr *config.Manager
+}
+
+func WrapClient(c *mongo.Client, mgr *config.Manager) *WrappedClient {
+	return &WrappedClient{Client: c, mgr: mgr}
+}
+
+func (w *WrappedClient) Database(name string, opts ...interface{}) *Database {
+	if w == nil || w.Client == nil {
+		return &Database{name: name}
+	}
+	return &Database{db: w.Client.Database(name), mgr: w.mgr, name: name}
+}
+
+type Database struct {
+	db   *mongo.Database
+	mgr  *config.Manager
+	name string
+}
+
+func (d *Database) RunCommand(ctx context.Context, runCommand interface{}, opts ...interface{}) *mongo.SingleResult {
+	if err := d.applyChaos(ctx, "runCommand"); err != nil {
+		return mongo.NewSingleResultFromDocument(nil, err, nil)
+	}
+	if d.db == nil {
+		return mongo.NewSingleResultFromDocument(nil, errors.New("pastaay: mongo database unavailable"), nil)
+	}
+	return d.db.RunCommand(ctx, runCommand)
+}
+
+func (d *Database) applyChaos(ctx context.Context, op string) error {
+	if d == nil || d.mgr == nil {
+		return nil
+	}
+	if d.mgr.IsCommandIgnored("mongo", op) {
+		return nil
+	}
+	for _, p := range d.mgr.GetActivePolicies("mongo") {
+		if !(strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, op)) {
+			continue
+		}
+		latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+		errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+		if latencyHit && errorHit {
+			latencyHit = false
+		}
+		if latencyHit {
+			metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "latency").Inc()
+			spanCtx, span := tracing.StartChaosSpan(ctx, "pastaay.mongo.latency", op, "latency")
+			telemetry.EmitInfo("mongo", "Mongo Latency Injected", map[string]interface{}{
+				"duration": p.LatencyDuration.String(), "target": op,
+			}, span)
+			timer := time.NewTimer(p.LatencyDuration)
+			select {
+			case <-timer.C:
+				timer.Stop()
+				span.End()
+			case <-spanCtx.Done():
+				timer.Stop()
+				span.End()
+				return spanCtx.Err()
+			}
+		}
+		if errorHit {
+			metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "error").Inc()
+			_, span := tracing.StartChaosSpan(ctx, "pastaay.mongo.error", op, "error")
+			defer span.End()
+			msg := p.ErrorBody
+			if msg == "" {
+				msg = "pastaay: synthetic mongo fault"
+			}
+			telemetry.EmitError("mongo", op, "Mongo Fault Injected", msg, span)
+			return errors.New(msg)
+		}
+	}
+	return nil
+}

--- a/pkg/oracle/client.go
+++ b/pkg/oracle/client.go
@@ -16,12 +16,15 @@ import (
 const (
 	maxLLMResponseBytes = 4 << 20
 	defaultLLMTimeout   = 30 * time.Second
+	userAgent           = "pastaay-oracle/2.0"
 )
 
 var sharedLLMClient = &http.Client{Timeout: defaultLLMTimeout}
 
 func AskOracle(provider, key, model, intensity, userPrompt, sysContext string) (string, error) {
-	return AskOracleCtx(context.Background(), provider, key, model, intensity, userPrompt, sysContext)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultLLMTimeout)
+	defer cancel()
+	return AskOracleCtx(ctx, provider, key, model, intensity, userPrompt, sysContext)
 }
 
 func AskOracleCtx(ctx context.Context, provider, key, model, intensity, userPrompt, sysContext string) (string, error) {
@@ -112,6 +115,7 @@ func buildJSONRequest(ctx context.Context, method, url string, payload interface
 		return nil, fmt.Errorf("request build: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
 	return req, nil
 }
 
@@ -148,8 +152,6 @@ func callLLM(ctx context.Context, apiKey, model, url, sysPrompt, userPrompt, pro
 }
 
 func callGemini(ctx context.Context, apiKey, model, sysPrompt, userPrompt string) (string, error) {
-	// Pass the key via x-goog-api-key header, NOT as a URL query parameter,
-	// so that intermediate logs and OTel HTTP middleware do not capture it.
 	url := "https://generativelanguage.googleapis.com/v1beta/models/" + model + ":generateContent"
 	payload := map[string]interface{}{
 		"system_instruction": map[string]interface{}{"parts": map[string]string{"text": sysPrompt}},
@@ -236,10 +238,13 @@ func executeRequest(req *http.Request, provider string, parser func([]byte) (str
 	return text, nil
 }
 
-// truncate rounds to a UTF-8 boundary so we never split a multi-byte codepoint.
+// truncate rounds to a UTF-8 boundary. n<=0 returns only the marker.
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
+	}
+	if n <= 0 {
+		return "...(truncated)"
 	}
 	cut := n
 	for cut > 0 && !utf8.RuneStart(s[cut]) {
@@ -248,15 +253,31 @@ func truncate(s string, n int) string {
 	return s[:cut] + "...(truncated)"
 }
 
+// ExtractYAML scans the response for ```yaml or ```yml fences
 func ExtractYAML(response string) string {
-	start := strings.Index(response, "```yaml")
-	if start == -1 {
-		return ""
+	for i := 0; i+2 < len(response); i++ {
+		if response[i] != '`' || response[i+1] != '`' || response[i+2] != '`' {
+			continue
+		}
+		rest := response[i+3:]
+		var fenceLen int
+		switch {
+		case len(rest) >= 4 && strings.EqualFold(rest[:4], "yaml"):
+			fenceLen = 4
+		case len(rest) >= 3 && strings.EqualFold(rest[:3], "yml"):
+			fenceLen = 3
+		default:
+			continue
+		}
+		start := i + 3 + fenceLen
+		if start > len(response) {
+			return ""
+		}
+		end := strings.Index(response[start:], "```")
+		if end == -1 {
+			return ""
+		}
+		return strings.TrimSpace(response[start : start+end])
 	}
-	start += 7
-	end := strings.Index(response[start:], "```")
-	if end == -1 {
-		return ""
-	}
-	return strings.TrimSpace(response[start : start+end])
+	return ""
 }

--- a/pkg/oracle/client.go
+++ b/pkg/oracle/client.go
@@ -2,6 +2,7 @@ package oracle
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,24 +10,68 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
+const (
+	maxLLMResponseBytes = 4 << 20
+	defaultLLMTimeout   = 30 * time.Second
+)
+
+var sharedLLMClient = &http.Client{Timeout: defaultLLMTimeout}
+
 func AskOracle(provider, key, model, intensity, userPrompt, sysContext string) (string, error) {
-	intensityGuide := ""
+	return AskOracleCtx(context.Background(), provider, key, model, intensity, userPrompt, sysContext)
+}
+
+func AskOracleCtx(ctx context.Context, provider, key, model, intensity, userPrompt, sysContext string) (string, error) {
+	intensityGuide := buildIntensityGuide(intensity)
+	systemPrompt := buildSystemPrompt(intensityGuide)
+	finalPrompt := fmt.Sprintf("User Request: %s\n\n--- LIVE TELEMETRY MATRIX ---\n%s", userPrompt, sysContext)
+
+	switch strings.ToLower(provider) {
+	case "openai":
+		if model == "" {
+			model = "gpt-4o-mini"
+		}
+		return callLLM(ctx, key, model, "https://api.openai.com/v1/chat/completions", systemPrompt, finalPrompt, "openai")
+	case "deepseek":
+		if model == "" {
+			model = "deepseek-reasoner"
+		}
+		return callLLM(ctx, key, model, "https://api.deepseek.com/v1/chat/completions", systemPrompt, finalPrompt, "deepseek")
+	case "gemini":
+		if model == "" {
+			model = "gemini-2.5-flash"
+		}
+		return callGemini(ctx, key, model, systemPrompt, finalPrompt)
+	case "anthropic":
+		if model == "" {
+			model = "claude-sonnet-4-6"
+		}
+		return callAnthropic(ctx, key, model, systemPrompt, finalPrompt)
+	default:
+		return "", fmt.Errorf("unknown provider: %s", provider)
+	}
+}
+
+func buildIntensityGuide(intensity string) string {
 	switch strings.ToLower(intensity) {
 	case "low":
-		intensityGuide = "INTENSITY LEVEL LOW: Use low probabilities (0.1-0.2) and very mild latency (100ms-300ms). Do NOT drop connections."
+		return "INTENSITY LEVEL LOW: Use low probabilities (0.1-0.2) and very mild latency (100ms-300ms). Do NOT drop connections."
 	case "medium":
-		intensityGuide = "INTENSITY LEVEL MEDIUM: Use moderate probabilities (0.3-0.6) and noticeable latency (500ms-2s)."
+		return "INTENSITY LEVEL MEDIUM: Use moderate probabilities (0.3-0.6) and noticeable latency (500ms-2s)."
 	case "high":
-		intensityGuide = "INTENSITY LEVEL HIGH: Use severe probabilities (0.7-0.9), extreme latency (3s-8s), and enable drop_connection."
+		return "INTENSITY LEVEL HIGH: Use severe probabilities (0.7-0.9), extreme latency (3s-8s), and enable drop_connection."
 	case "nuke":
-		intensityGuide = "INTENSITY LEVEL NUKE: MAXIMUM DESTRUCTION. Use 1.0 probabilities, 15s+ latencies, drop ALL connections, and trigger brutal resource starvation (RAM/CPU)."
+		return "INTENSITY LEVEL NUKE: MAXIMUM DESTRUCTION. Use 1.0 probabilities, 15s+ latencies, drop ALL connections, and trigger brutal resource starvation (RAM/CPU)."
 	default:
-		intensityGuide = "Use moderate SRE chaos parameters."
+		return "Use moderate SRE chaos parameters."
 	}
+}
 
-	systemPrompt := "You are Pastaay Oracle, a Senior Site Reliability Engineering (SRE) AI.\n" +
+func buildSystemPrompt(intensityGuide string) string {
+	return "You are Pastaay Oracle, a Senior Site Reliability Engineering (SRE) AI.\n" +
 		"Analyze the provided telemetry and system configuration matrices.\n" +
 		"Your ONLY output must be a highly complex, devastating, multi-layered Chaos Engineering blueprint in valid Pastaay V1 YAML wrapped in a markdown yaml block.\n\n" +
 		"CRITICAL DIRECTIVES:\n" +
@@ -47,49 +92,22 @@ func AskOracle(provider, key, model, intensity, userPrompt, sysContext string) (
 		"  - name: <aggressive-scenario-name>\n" +
 		"    type: <http|sql|grpc|redis|mongo|kafka|rabbitmq|resource>\n" +
 		"    target: <specific-target-from-metrics>\n" +
-		"    latency_chance: <0.1-1.0> # OMIT IF 0\n" +
+		"    latency_chance: <0.1-1.0>\n" +
 		"    latency_duration: <duration>\n" +
-		"    error_chance: <0.1-1.0> # OMIT IF 0\n" +
+		"    error_chance: <0.1-1.0>\n" +
 		"    error_code: <int>\n" +
 		"    drop_connection: <bool>\n" +
-		"    throttle_threshold: <int> # RESOURCE ONLY\n" +
-		"    ram_chunk_mb: <int> # RESOURCE ONLY\n" +
-		"    ram_interval: <duration> # RESOURCE ONLY"
-
-	finalPrompt := fmt.Sprintf("User Request: %s\n\n--- LIVE TELEMETRY MATRIX ---\n%s", userPrompt, sysContext)
-
-	switch strings.ToLower(provider) {
-	case "openai":
-		if model == "" {
-			model = "gpt-4o-mini"
-		}
-		return callLLM(key, model, "https://api.openai.com/v1/chat/completions", systemPrompt, finalPrompt, "openai")
-	case "deepseek":
-		if model == "" {
-			model = "deepseek-reasoner"
-		}
-		return callLLM(key, model, "https://api.deepseek.com/v1/chat/completions", systemPrompt, finalPrompt, "deepseek")
-	case "gemini":
-		if model == "" {
-			model = "gemini-2.5-flash"
-		}
-		return callGemini(key, model, systemPrompt, finalPrompt)
-	case "anthropic":
-		if model == "" {
-			model = "claude-sonnet-4-6"
-		}
-		return callAnthropic(key, model, systemPrompt, finalPrompt)
-	default:
-		return "", fmt.Errorf("unknown provider: %s", provider)
-	}
+		"    throttle_threshold: <int>\n" +
+		"    ram_chunk_mb: <int>\n" +
+		"    ram_interval: <duration>"
 }
 
-func buildJSONRequest(method, url string, payload interface{}) (*http.Request, error) {
+func buildJSONRequest(ctx context.Context, method, url string, payload interface{}) (*http.Request, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("payload marshal: %w", err)
 	}
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("request build: %w", err)
 	}
@@ -97,7 +115,7 @@ func buildJSONRequest(method, url string, payload interface{}) (*http.Request, e
 	return req, nil
 }
 
-func callLLM(apiKey, model, url, sysPrompt, userPrompt, provider string) (string, error) {
+func callLLM(ctx context.Context, apiKey, model, url, sysPrompt, userPrompt, provider string) (string, error) {
 	payload := map[string]interface{}{
 		"model": model,
 		"messages": []map[string]string{
@@ -106,7 +124,7 @@ func callLLM(apiKey, model, url, sysPrompt, userPrompt, provider string) (string
 		},
 		"temperature": 0.5,
 	}
-	req, err := buildJSONRequest(http.MethodPost, url, payload)
+	req, err := buildJSONRequest(ctx, http.MethodPost, url, payload)
 	if err != nil {
 		return "", err
 	}
@@ -120,26 +138,29 @@ func callLLM(apiKey, model, url, sysPrompt, userPrompt, provider string) (string
 			} `json:"choices"`
 		}
 		if err := json.Unmarshal(b, &res); err != nil {
-			return "", fmt.Errorf("openai response decode: %w (raw=%q)", err, truncate(string(b), 256))
+			return "", fmt.Errorf("%s response decode: %w (raw=%q)", provider, err, truncate(string(b), 256))
 		}
 		if len(res.Choices) == 0 {
-			return "", fmt.Errorf("openai response had no choices (raw=%q)", truncate(string(b), 256))
+			return "", fmt.Errorf("%s response had no choices (raw=%q)", provider, truncate(string(b), 256))
 		}
 		return res.Choices[0].Message.Content, nil
 	})
 }
 
-func callGemini(apiKey, model, sysPrompt, userPrompt string) (string, error) {
-	url := "https://generativelanguage.googleapis.com/v1beta/models/" + model + ":generateContent?key=" + apiKey
+func callGemini(ctx context.Context, apiKey, model, sysPrompt, userPrompt string) (string, error) {
+	// Pass the key via x-goog-api-key header, NOT as a URL query parameter,
+	// so that intermediate logs and OTel HTTP middleware do not capture it.
+	url := "https://generativelanguage.googleapis.com/v1beta/models/" + model + ":generateContent"
 	payload := map[string]interface{}{
 		"system_instruction": map[string]interface{}{"parts": map[string]string{"text": sysPrompt}},
 		"contents":           []map[string]interface{}{{"parts": []map[string]string{{"text": userPrompt}}}},
 		"generationConfig":   map[string]interface{}{"temperature": 0.5},
 	}
-	req, err := buildJSONRequest(http.MethodPost, url, payload)
+	req, err := buildJSONRequest(ctx, http.MethodPost, url, payload)
 	if err != nil {
 		return "", err
 	}
+	req.Header.Set("x-goog-api-key", apiKey)
 	return executeRequest(req, "gemini", func(b []byte) (string, error) {
 		var res struct {
 			Candidates []struct {
@@ -160,7 +181,7 @@ func callGemini(apiKey, model, sysPrompt, userPrompt string) (string, error) {
 	})
 }
 
-func callAnthropic(apiKey, model, sysPrompt, userPrompt string) (string, error) {
+func callAnthropic(ctx context.Context, apiKey, model, sysPrompt, userPrompt string) (string, error) {
 	payload := map[string]interface{}{
 		"model":       model,
 		"max_tokens":  1500,
@@ -168,7 +189,7 @@ func callAnthropic(apiKey, model, sysPrompt, userPrompt string) (string, error) 
 		"messages":    []map[string]string{{"role": "user", "content": userPrompt}},
 		"temperature": 0.5,
 	}
-	req, err := buildJSONRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", payload)
+	req, err := buildJSONRequest(ctx, http.MethodPost, "https://api.anthropic.com/v1/messages", payload)
 	if err != nil {
 		return "", err
 	}
@@ -191,15 +212,18 @@ func callAnthropic(apiKey, model, sysPrompt, userPrompt string) (string, error) 
 }
 
 func executeRequest(req *http.Request, provider string, parser func([]byte) (string, error)) (string, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := sharedLLMClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("%s transport: %w", provider, err)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	limited := io.LimitReader(resp.Body, maxLLMResponseBytes+1)
+	body, err := io.ReadAll(limited)
 	if err != nil {
 		return "", fmt.Errorf("%s body read: %w", provider, err)
+	}
+	if int64(len(body)) > maxLLMResponseBytes {
+		return "", fmt.Errorf("%s response exceeded %d byte cap", provider, maxLLMResponseBytes)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("%s API error %d: %s", provider, resp.StatusCode, truncate(string(body), 512))
@@ -212,11 +236,16 @@ func executeRequest(req *http.Request, provider string, parser func([]byte) (str
 	return text, nil
 }
 
+// truncate rounds to a UTF-8 boundary so we never split a multi-byte codepoint.
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return s[:n] + "...(truncated)"
+	cut := n
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "...(truncated)"
 }
 
 func ExtractYAML(response string) string {

--- a/pkg/oracle/client_test.go
+++ b/pkg/oracle/client_test.go
@@ -1,0 +1,103 @@
+package oracle
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAskOracle_DefaultTimeoutWiring(t *testing.T) {
+	start := time.Now()
+	_, err := AskOracle("unknown", "", "", "low", "ping", "")
+	if err == nil {
+		t.Fatal("expected unknown-provider error")
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Fatal("AskOracle did not respect default timeout")
+	}
+}
+
+func TestAskOracleCtx_RespectsCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := AskOracleCtx(ctx, "unknown", "", "", "low", "x", "")
+	if err == nil {
+		t.Fatal("expected error on cancelled context with bad provider")
+	}
+}
+
+func TestExtractYAML_FenceVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercase-yaml", "```yaml\nversion: 1\n```", "version: 1"},
+		{"uppercase-yaml", "```YAML\nversion: 1\n```", "version: 1"},
+		{"yml-fence", "```yml\nversion: 1\n```", "version: 1"},
+		{"no-fence", "version: 1", ""},
+		{"unclosed-fence", "```yaml\nversion: 1", ""},
+		{"with-prefix", "Here is the config:\n```yaml\nversion: 1\npolicies: []\n```\nDone.", "version: 1\npolicies: []"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExtractYAML(c.in)
+			if got != c.want {
+				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTruncate_MultiByteBoundary(t *testing.T) {
+	// cut at 5 should land on a rune boundary.
+	s := "✨ " + strings.Repeat("x", 100)
+	got := truncate(s, 5)
+	if got == "" {
+		t.Fatal("truncate dropped the entire string")
+	}
+	if !strings.Contains(got, "...(truncated)") {
+		t.Fatal("truncate marker missing")
+	}
+}
+
+func TestTruncate_ShortStringUnchanged(t *testing.T) {
+	if got := truncate("hi", 100); got != "hi" {
+		t.Fatalf("short string mutated: %q", got)
+	}
+}
+
+func TestBuildSystemPrompt_HasIntensityClause(t *testing.T) {
+	sp := buildSystemPrompt(buildIntensityGuide("nuke"))
+	if !strings.Contains(sp, "MAXIMUM DESTRUCTION") {
+		t.Fatal("nuke intensity not propagated into prompt")
+	}
+}
+
+func TestExtractYAML_PreservesCasingAndAvoidsFullLower(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"```YAML\nVersion: 1\n```", "Version: 1"},
+		{"```Yml\nFOO: BaR\n```", "FOO: BaR"},
+		{"prefix\n```yaml\nfoo: \"BaR\"\n```\nsuffix", "foo: \"BaR\""},
+	}
+	for i, c := range cases {
+		if got := ExtractYAML(c.in); got != c.want {
+			t.Fatalf("case %d: got %q want %q", i, got, c.want)
+		}
+	}
+}
+
+func BenchmarkExtractYAML_LargeBody(b *testing.B) {
+	body := strings.Repeat("noise line\n", 1024) +
+		"```yaml\nversion: 1\npolicies: []\n```\n" +
+		strings.Repeat("trailing noise\n", 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ExtractYAML(body)
+	}
+}

--- a/pkg/redischaos/dialer.go
+++ b/pkg/redischaos/dialer.go
@@ -14,7 +14,7 @@ import (
 
 type DialerFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
-// NewChaosDialer returns a dialer that may refuse to establish a connection when an active policy has drop_connection enabled.
+// NewChaosDialer returns a dialer that enforces drop_connection policies.
 func NewChaosDialer(mgr *config.Manager, baseDialer DialerFunc) DialerFunc {
 	if baseDialer == nil {
 		d := &net.Dialer{Timeout: 5 * time.Second}

--- a/pkg/redischaos/dialer.go
+++ b/pkg/redischaos/dialer.go
@@ -14,6 +14,7 @@ import (
 
 type DialerFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
+// NewChaosDialer returns a dialer that may refuse to establish a connection when an active policy has drop_connection enabled.
 func NewChaosDialer(mgr *config.Manager, baseDialer DialerFunc) DialerFunc {
 	if baseDialer == nil {
 		d := &net.Dialer{Timeout: 5 * time.Second}

--- a/pkg/redischaos/hook.go
+++ b/pkg/redischaos/hook.go
@@ -31,37 +31,42 @@ func (h *ChaosHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 
 		policies := h.mgr.GetActivePolicies("redis")
 		for _, p := range policies {
-			if strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, cmd.Name()) {
+			if !(strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, cmd.Name())) {
+				continue
+			}
 
-				metricTag := p.MetricTag
+			metricTag := p.MetricTag
 
-				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
-					metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "latency").Inc()
-					spanCtx, span := tracing.StartChaosSpan(ctx, "pastaay.redis.latency", cmd.Name(), "latency")
+			latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+			errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+			if latencyHit && errorHit {
+				latencyHit = false
+			}
 
-					telemetry.EmitInfo("redis", "Redis Latency Injected", map[string]interface{}{"duration": p.LatencyDuration.String(), "target": cmd.Name()}, span)
+			if latencyHit {
+				metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "latency").Inc()
+				spanCtx, span := tracing.StartChaosSpan(ctx, "pastaay.redis.latency", cmd.Name(), "latency")
 
-					timer := time.NewTimer(p.LatencyDuration)
-					select {
-					case <-timer.C:
-						timer.Stop()
-						span.End()
-					case <-spanCtx.Done():
-						timer.Stop()
-						span.End()
-						return spanCtx.Err()
-					}
-				}
-				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
-					metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "error").Inc()
-					_, span := tracing.StartChaosSpan(ctx, "pastaay.redis.error", cmd.Name(), "error")
+				telemetry.EmitInfo("redis", "Redis Latency Injected", map[string]interface{}{"duration": p.LatencyDuration.String(), "target": cmd.Name()}, span)
 
-					telemetry.EmitError("redis", cmd.Name(), "Redis Fault Injected", p.ErrorBody, span)
-
+				timer := time.NewTimer(p.LatencyDuration)
+				select {
+				case <-timer.C:
+					timer.Stop()
 					span.End()
-					return errors.New("pastaay: synthetic redis fault")
+				case <-spanCtx.Done():
+					timer.Stop()
+					span.End()
+					return spanCtx.Err()
 				}
+			}
 
+			if errorHit {
+				metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "error").Inc()
+				_, span := tracing.StartChaosSpan(ctx, "pastaay.redis.error", cmd.Name(), "error")
+				telemetry.EmitError("redis", cmd.Name(), "Redis Fault Injected", p.ErrorBody, span)
+				span.End()
+				return errors.New("pastaay: synthetic redis fault")
 			}
 		}
 		return next(ctx, cmd)
@@ -73,7 +78,7 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 		policies := h.mgr.GetActivePolicies("redis")
 		var maxLatency time.Duration
 		var latencyTag string
-		var errorTag string
+		errorTags := make([]string, 0, 4)
 		hasError := false
 
 		protected := make([]bool, len(cmds))
@@ -86,8 +91,8 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 			anyUnprotected = true
 		}
 
-		// Roll dice ONCE per policy across the whole pipeline
 		if anyUnprotected {
+			seenTags := make(map[string]struct{}, len(policies))
 			for _, p := range policies {
 				matchesAny := false
 				for i := range cmds {
@@ -102,15 +107,23 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 				if !matchesAny {
 					continue
 				}
-				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
+				latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+				errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+				if latencyHit && errorHit {
+					latencyHit = false
+				}
+				if latencyHit {
 					if p.LatencyDuration > maxLatency {
 						maxLatency = p.LatencyDuration
 						latencyTag = p.MetricTag
 					}
 				}
-				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
+				if errorHit {
 					hasError = true
-					errorTag = p.MetricTag
+					if _, dup := seenTags[p.MetricTag]; !dup {
+						seenTags[p.MetricTag] = struct{}{}
+						errorTags = append(errorTags, p.MetricTag)
+					}
 				}
 			}
 		}
@@ -145,11 +158,15 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 				return next(ctx, cmds)
 			}
 
-			targetTag := "redis:all"
-			if errorTag != "" {
-				targetTag = errorTag
+			// Stable, multi-tag attribution rather than "last wins".
+			tag := "redis:pipeline"
+			if len(errorTags) > 0 {
+				tag = errorTags[0]
+				if len(errorTags) > 1 {
+					tag += "+" + errorTags[len(errorTags)-1]
+				}
 			}
-			metrics.InjectedFaultsTotal.WithLabelValues(targetTag, "error").Inc()
+			metrics.InjectedFaultsTotal.WithLabelValues(tag, "error").Inc()
 			_, span := tracing.StartChaosSpan(ctx, "pastaay.redis.pipeline_error", "pipeline", "error")
 			defer span.End()
 
@@ -168,6 +185,25 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 	}
 }
 
+// DialHook drops connections when drop_connection policy matches.
 func (h *ChaosHook) DialHook(next redis.DialHook) redis.DialHook {
-	return func(ctx context.Context, network, addr string) (net.Conn, error) { return next(ctx, network, addr) }
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if h == nil || h.mgr == nil {
+			return next(ctx, network, addr)
+		}
+		policies := h.mgr.GetActivePolicies("redis")
+		for _, p := range policies {
+			if p.DropConnection && (strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, "database")) {
+				chance := p.ErrorChance
+				if chance == 0 {
+					chance = 1.0
+				}
+				if rand.Float64() < chance {
+					metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "drop").Inc()
+					return nil, errors.New("[Pastaay-Redis] Chaos: TCP connection forcefully dropped (hook)")
+				}
+			}
+		}
+		return next(ctx, network, addr)
+	}
 }

--- a/pkg/redischaos/hook.go
+++ b/pkg/redischaos/hook.go
@@ -59,7 +59,7 @@ func (h *ChaosHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 					telemetry.EmitError("redis", cmd.Name(), "Redis Fault Injected", p.ErrorBody, span)
 
 					span.End()
-					return redis.Nil
+					return errors.New("pastaay: synthetic redis fault")
 				}
 
 			}
@@ -77,25 +77,40 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 		hasError := false
 
 		protected := make([]bool, len(cmds))
-
+		anyUnprotected := false
 		for i := range cmds {
-			cmd := cmds[i]
-			if h.mgr.IsCommandIgnored("redis", cmd.Name()) {
+			if h.mgr.IsCommandIgnored("redis", cmds[i].Name()) {
 				protected[i] = true
 				continue
 			}
+			anyUnprotected = true
+		}
+
+		// Roll dice ONCE per policy across the whole pipeline
+		if anyUnprotected {
 			for _, p := range policies {
-				if strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, cmd.Name()) {
-					if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
-						if p.LatencyDuration > maxLatency {
-							maxLatency = p.LatencyDuration
-							latencyTag = p.MetricTag
-						}
+				matchesAny := false
+				for i := range cmds {
+					if protected[i] {
+						continue
 					}
-					if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
-						hasError = true
-						errorTag = p.MetricTag
+					if strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, cmds[i].Name()) {
+						matchesAny = true
+						break
 					}
+				}
+				if !matchesAny {
+					continue
+				}
+				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
+					if p.LatencyDuration > maxLatency {
+						maxLatency = p.LatencyDuration
+						latencyTag = p.MetricTag
+					}
+				}
+				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
+					hasError = true
+					errorTag = p.MetricTag
 				}
 			}
 		}
@@ -103,8 +118,9 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 		if maxLatency > 0 {
 			metrics.InjectedFaultsTotal.WithLabelValues(latencyTag, "latency").Inc()
 			spanCtx, span := tracing.StartChaosSpan(ctx, "pastaay.redis.pipeline_latency", "pipeline", "latency")
-			telemetry.EmitInfo("redis", "Redis Pipeline Latency Injected", map[string]interface{}{"duration": maxLatency.String(), "target": "pipeline"}, span)
-
+			telemetry.EmitInfo("redis", "Redis Pipeline Latency Injected", map[string]interface{}{
+				"duration": maxLatency.String(), "target": "pipeline",
+			}, span)
 			timer := time.NewTimer(maxLatency)
 			select {
 			case <-timer.C:
@@ -135,6 +151,7 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 			}
 			metrics.InjectedFaultsTotal.WithLabelValues(targetTag, "error").Inc()
 			_, span := tracing.StartChaosSpan(ctx, "pastaay.redis.pipeline_error", "pipeline", "error")
+			defer span.End()
 
 			chaosErr := errors.New("pastaay: redis pipeline batch aborted due to chaos policy")
 			for i := range cmds {
@@ -145,8 +162,6 @@ func (h *ChaosHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 			}
 
 			telemetry.EmitError("redis", "pipeline", "Redis Pipeline Batch Aborted", "batch aborted due to chaos policy", span)
-			span.End()
-
 			return chaosErr
 		}
 		return next(ctx, cmds)

--- a/pkg/redischaos/hook_test.go
+++ b/pkg/redischaos/hook_test.go
@@ -2,6 +2,7 @@ package redischaos
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/CemAkan/pastaay/pkg/config"
@@ -33,7 +34,10 @@ func TestRedisHook_ErrorInjection(t *testing.T) {
 
 	err := processHook(context.Background(), &mockCmder{name: "get"})
 
-	if err != redis.Nil {
-		t.Errorf("expected redis.Nil error, got %v", err)
-	}
+		if err == nil {
+			t.Errorf("expected non-nil chaos error, got nil")
+		}
+		if !strings.Contains(err.Error(), "pastaay: synthetic redis fault") {
+			t.Errorf("expected synthetic fault, got %v", err)
+		}
 }

--- a/pkg/redischaos/hook_test.go
+++ b/pkg/redischaos/hook_test.go
@@ -19,6 +19,7 @@ func (m *mockCmder) Name() string { return m.name }
 
 func TestRedisHook_ErrorInjection(t *testing.T) {
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:        "redis",

--- a/pkg/ritual/middleware.go
+++ b/pkg/ritual/middleware.go
@@ -27,44 +27,25 @@ func Middleware(mgr *config.Manager) func(http.Handler) http.Handler {
 					continue
 				}
 
-				metricTag := p.MetricTag
+				latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+				errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
 
-				if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
-					metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "latency").Inc()
-					ctx, span := tracing.StartChaosSpan(r.Context(), "pastaay.http.latency", p.Target, "latency")
-
-					telemetry.EmitInfo("http", "HTTP Latency Injected", map[string]interface{}{"duration": p.LatencyDuration.String(), "target": p.Target}, span)
-
-					timer := time.NewTimer(p.LatencyDuration)
-					select {
-					case <-timer.C:
-						span.End()
-					case <-ctx.Done():
-						timer.Stop()
-						span.End()
-						w.WriteHeader(499)
-						return
-					}
+				if latencyHit && errorHit {
+					// Tie-break
+					latencyHit = false
 				}
 
-				if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
-					metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "error").Inc()
-					_, span := tracing.StartChaosSpan(r.Context(), "pastaay.http.error", p.Target, "error")
-					defer span.End()
-
-					status := p.ErrorCode
-					if status == 0 {
-						status = http.StatusInternalServerError
+				if latencyHit {
+					if injectLatency(w, r, p) {
+						// Client disconnected during latency
+						return
 					}
+					// Latency injected
+					continue
+				}
 
-					telemetry.EmitError("http", p.Target, "HTTP Fault Injected", p.ErrorBody, span)
-
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(status)
-
-					if p.ErrorBody != "" {
-						_, _ = io.WriteString(w, p.ErrorBody)
-					}
+				if errorHit {
+					injectError(w, r, p)
 					return
 				}
 			}
@@ -73,7 +54,50 @@ func Middleware(mgr *config.Manager) func(http.Handler) http.Handler {
 	}
 }
 
-// matchPath checks whether reqPath is covered by the policy, handling exact matches, wildcards (target ending with *), and the "all" sentinel.
+// injectLatency blocks for the policy duration or until ctx is done.
+func injectLatency(w http.ResponseWriter, r *http.Request, p *config.Policy) bool {
+	metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "latency").Inc()
+	ctx, span := tracing.StartChaosSpan(r.Context(), "pastaay.http.latency", p.Target, "latency")
+	defer span.End()
+
+	telemetry.EmitInfo("http", "HTTP Latency Injected", map[string]interface{}{
+		"duration": p.LatencyDuration.String(),
+		"target":   p.Target,
+	}, span)
+
+	timer := time.NewTimer(p.LatencyDuration)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return false
+	case <-ctx.Done():
+		// Nginx-style "client closed request" status.
+		w.WriteHeader(499)
+		return true
+	}
+}
+
+func injectError(w http.ResponseWriter, r *http.Request, p *config.Policy) {
+	metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "error").Inc()
+	_, span := tracing.StartChaosSpan(r.Context(), "pastaay.http.error", p.Target, "error")
+	defer span.End()
+
+	status := p.ErrorCode
+	if status == 0 {
+		status = http.StatusInternalServerError
+	}
+
+	telemetry.EmitError("http", p.Target, "HTTP Fault Injected", p.ErrorBody, span)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if p.ErrorBody != "" {
+		_, _ = io.WriteString(w, p.ErrorBody)
+	}
+}
+
+// matchPath checks whether reqPath is covered by the policy.
 func matchPath(reqPath string, p *config.Policy) bool {
 	if strings.EqualFold(p.Target, "all") || strings.EqualFold(reqPath, p.Target) {
 		return true

--- a/pkg/ritual/middleware.go
+++ b/pkg/ritual/middleware.go
@@ -73,6 +73,7 @@ func Middleware(mgr *config.Manager) func(http.Handler) http.Handler {
 	}
 }
 
+// matchPath checks whether reqPath is covered by the policy, handling exact matches, wildcards (target ending with *), and the "all" sentinel.
 func matchPath(reqPath string, p *config.Policy) bool {
 	if strings.EqualFold(p.Target, "all") || strings.EqualFold(reqPath, p.Target) {
 		return true

--- a/pkg/ritual/middleware_test.go
+++ b/pkg/ritual/middleware_test.go
@@ -1,10 +1,14 @@
 package ritual
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/CemAkan/pastaay/pkg/config"
 )
@@ -65,6 +69,7 @@ func TestMatchPath(t *testing.T) {
 
 func TestMiddleware_ErrorInjection(t *testing.T) {
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:        "http",
@@ -102,5 +107,172 @@ func TestMiddleware_ErrorInjection(t *testing.T) {
 
 	if rrPass.Code != http.StatusOK {
 		t.Errorf("Expected status %d for bypassed route, got %d", http.StatusOK, rrPass.Code)
+	}
+}
+func TestMiddleware_LatencyOrError_NeverBoth(t *testing.T) {
+	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
+		Policies: []config.Policy{{
+			Type:            "http",
+			Target:          "/x",
+			LatencyChance:   1.0,
+			ErrorChance:     1.0,
+			LatencyDuration: 5 * time.Millisecond,
+			ErrorCode:       418,
+			ErrorBody:       `{"err":"teapot"}`,
+		}},
+	})
+
+	var nextCalled atomic.Bool
+	mw := Middleware(mgr)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Tie-break
+	for i := 0; i < 64; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		rr := httptest.NewRecorder()
+		start := time.Now()
+		mw.ServeHTTP(rr, req)
+		elapsed := time.Since(start)
+		if rr.Code != http.StatusTeapot {
+			t.Fatalf("iteration %d: tie-break must be error (418), got %d", i, rr.Code)
+		}
+		// Error path must NOT block on the latency timer.
+		if elapsed > 4*time.Millisecond {
+			t.Fatalf("iteration %d: error path took %v — latency timer leaked", i, elapsed)
+		}
+		if nextCalled.Load() {
+			t.Fatalf("error path must short-circuit, next handler must not run")
+		}
+		nextCalled.Store(false)
+	}
+}
+
+func TestMiddleware_LatencyPath_NoGoroutineLeak(t *testing.T) {
+	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
+		Policies: []config.Policy{{
+			Type:            "http",
+			Target:          "/x",
+			LatencyChance:   1.0,
+			LatencyDuration: 1 * time.Millisecond,
+		}},
+	})
+	mw := Middleware(mgr)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Warm up.
+	for i := 0; i < 100; i++ {
+		mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/x", nil))
+	}
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 4000; i++ {
+		mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/x", nil))
+	}
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	if after > before+5 {
+		t.Fatalf("goroutine leak detected: before=%d after=%d", before, after)
+	}
+}
+
+func TestMiddleware_ClientDisconnectDuringLatency(t *testing.T) {
+	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
+		Policies: []config.Policy{{
+			Type:            "http",
+			Target:          "/slow",
+			LatencyChance:   1.0,
+			LatencyDuration: 30 * time.Minute,
+		}},
+	})
+	mw := Middleware(mgr)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/slow", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		mw.ServeHTTP(rr, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("middleware did not unblock on context cancel")
+	}
+	if rr.Code != 499 {
+		t.Errorf("expected 499 (client closed), got %d", rr.Code)
+	}
+}
+
+func TestMatchPath_WildcardEdgeCases(t *testing.T) {
+	tests := []struct {
+		req    string
+		target string
+		want   bool
+	}{
+		{"/api", "/api/*", false}, // slash boundary required
+		{"/api/", "/api/*", true},
+		{"/api/foo", "/api/*", true},
+		{"/api/foo/bar", "/api/*", true},
+		{"/apix", "/api/*", false},
+		{"/api", "/api*", true}, // bare-prefix wildcard
+		{"/api/foo", "/api*", true},
+		{"/apix", "/api*", false}, // mid-token NOT matched
+		{"/", "all", true},
+		{"/v2", "/v1/*", false},
+	}
+	for _, tc := range tests {
+		p := &config.Policy{Target: tc.target}
+		if len(tc.target) > 0 && tc.target[len(tc.target)-1] == '*' {
+			p.IsWildcard = true
+			// emulate manager.go normalization
+			p.WildcardPrefix = ""
+			for _, c := range tc.target[:len(tc.target)-1] {
+				if c >= 'a' && c <= 'z' {
+					c -= 32
+				}
+				p.WildcardPrefix += string(c)
+			}
+		}
+		if got := matchPath(tc.req, p); got != tc.want {
+			t.Errorf("matchPath(%q, target=%q) = %v, want %v", tc.req, tc.target, got, tc.want)
+		}
+	}
+}
+
+func BenchmarkMiddleware_NoMatchPath(b *testing.B) {
+	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
+		Policies: []config.Policy{
+			{Type: "http", Target: "/none1", ErrorChance: 1.0},
+			{Type: "http", Target: "/none2", ErrorChance: 1.0},
+			{Type: "http", Target: "/none3", ErrorChance: 1.0},
+		},
+	})
+	mw := Middleware(mgr)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest("GET", "/passthrough", nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rr := httptest.NewRecorder()
+		mw.ServeHTTP(rr, req)
 	}
 }

--- a/pkg/sqlchaos/connection.go
+++ b/pkg/sqlchaos/connection.go
@@ -16,13 +16,13 @@ import (
 
 type chaosKey struct{}
 
-// WrapperConn wraps a driver.Conn and evaluates SQL chaos policies on every query, exec, prepare, and begin‑transaction call.
+const legacyChaosTimeout = 30 * time.Second
+
 type WrapperConn struct {
 	originalConn driver.Conn
 	cfgManager   *config.Manager
 }
 
-// WrapperStmt wraps a driver.Stmt and re‑evaluates chaos policies on each execution using the pre‑cleaned query string.
 type WrapperStmt struct {
 	originalStmt driver.Stmt
 	cleanQuery   string
@@ -47,54 +47,60 @@ func applySQLChaos(ctx context.Context, mgr *config.Manager, cleanQuery string) 
 	shieldApplied := false
 
 	for _, p := range policies {
-		if isTargetMatch(cleanQuery, &p) {
-			if !shieldApplied {
-				currentCtx = context.WithValue(currentCtx, chaosKey{}, true)
-				shieldApplied = true
-			}
+		if !isTargetMatch(cleanQuery, &p) {
+			continue
+		}
+		if !shieldApplied {
+			currentCtx = context.WithValue(currentCtx, chaosKey{}, true)
+			shieldApplied = true
+		}
 
-			metricTag := p.MetricTag
+		metricTag := p.MetricTag
 
-			if p.LatencyChance > 0 && rand.Float64() < p.LatencyChance {
-				metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "latency").Inc()
-				spanCtx, span := tracing.StartChaosSpan(currentCtx, "pastaay.sql.latency", p.Target, "latency")
+		latencyHit := p.LatencyChance > 0 && rand.Float64() < p.LatencyChance
+		errorHit := p.ErrorChance > 0 && rand.Float64() < p.ErrorChance
+		if latencyHit && errorHit {
+			latencyHit = false
+		}
 
-				telemetry.EmitInfo("sql", "SQL Latency Injected", map[string]interface{}{"duration": p.LatencyDuration.String(), "target": p.Target}, span)
+		if latencyHit {
+			metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "latency").Inc()
+			spanCtx, span := tracing.StartChaosSpan(currentCtx, "pastaay.sql.latency", p.Target, "latency")
 
-				timer := time.NewTimer(p.LatencyDuration)
-				select {
-				case <-timer.C:
-					timer.Stop()
-					span.End()
-				case <-spanCtx.Done():
-					timer.Stop()
-					span.End()
-					return currentCtx, spanCtx.Err()
-				}
-			}
+			telemetry.EmitInfo("sql", "SQL Latency Injected", map[string]interface{}{"duration": p.LatencyDuration.String(), "target": p.Target}, span)
 
-			if p.ErrorChance > 0 && rand.Float64() < p.ErrorChance {
-				metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "error").Inc()
-				_, span := tracing.StartChaosSpan(currentCtx, "pastaay.sql.error", p.Target, "error")
-
-				msg := p.ErrorBody
-				if msg == "" {
-					msg = "sql: database connection is closed"
-				}
-
-				telemetry.EmitError("sql", p.Target, "SQL Fault Injected", msg, span)
-
+			timer := time.NewTimer(p.LatencyDuration)
+			select {
+			case <-timer.C:
+				timer.Stop()
 				span.End()
-				return currentCtx, errors.New(msg)
+			case <-spanCtx.Done():
+				timer.Stop()
+				span.End()
+				return currentCtx, spanCtx.Err()
 			}
+		}
+
+		if errorHit {
+			metrics.InjectedFaultsTotal.WithLabelValues(metricTag, "error").Inc()
+			_, span := tracing.StartChaosSpan(currentCtx, "pastaay.sql.error", p.Target, "error")
+			defer span.End()
+
+			msg := p.ErrorBody
+			if msg == "" {
+				msg = "sql: database connection is closed"
+			}
+
+			telemetry.EmitError("sql", p.Target, "SQL Fault Injected", msg, span)
+
+			return currentCtx, errors.New(msg)
 		}
 	}
 	return currentCtx, nil
 }
 
 func isTargetMatch(query string, p *config.Policy) bool {
-	target := strings.ToUpper(p.Target)
-	if target == "ALL" || target == "DATABASE" {
+	if strings.EqualFold(p.Target, "ALL") || strings.EqualFold(p.Target, "DATABASE") {
 		return true
 	}
 	if query == "" || p.CompiledRegex == nil {
@@ -164,12 +170,13 @@ func (c *WrapperConn) Prepare(query string) (driver.Stmt, error) {
 
 func (c *WrapperConn) Close() error { return c.originalConn.Close() }
 func (c *WrapperConn) Begin() (driver.Tx, error) {
-	return c.BeginTx(context.Background(), driver.TxOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), legacyChaosTimeout)
+	defer cancel()
+	return c.BeginTx(ctx, driver.TxOptions{})
 }
 
 func (s *WrapperStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	if ec, ok := s.originalStmt.(driver.StmtExecContext); ok {
-
 		newCtx, err := applySQLChaos(ctx, s.cfgManager, s.cleanQuery)
 		if err != nil {
 			return nil, err
@@ -191,14 +198,18 @@ func (s *WrapperStmt) QueryContext(ctx context.Context, args []driver.NamedValue
 }
 
 func (s *WrapperStmt) Exec(args []driver.Value) (driver.Result, error) {
-	if _, err := applySQLChaos(context.Background(), s.cfgManager, s.cleanQuery); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), legacyChaosTimeout)
+	defer cancel()
+	if _, err := applySQLChaos(ctx, s.cfgManager, s.cleanQuery); err != nil {
 		return nil, err
 	}
 	return s.originalStmt.Exec(args)
 }
 
 func (s *WrapperStmt) Query(args []driver.Value) (driver.Rows, error) {
-	if _, err := applySQLChaos(context.Background(), s.cfgManager, s.cleanQuery); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), legacyChaosTimeout)
+	defer cancel()
+	if _, err := applySQLChaos(ctx, s.cfgManager, s.cleanQuery); err != nil {
 		return nil, err
 	}
 	return s.originalStmt.Query(args)

--- a/pkg/sqlchaos/connection.go
+++ b/pkg/sqlchaos/connection.go
@@ -16,11 +16,13 @@ import (
 
 type chaosKey struct{}
 
+// WrapperConn wraps a driver.Conn and evaluates SQL chaos policies on every query, exec, prepare, and begin‑transaction call.
 type WrapperConn struct {
 	originalConn driver.Conn
 	cfgManager   *config.Manager
 }
 
+// WrapperStmt wraps a driver.Stmt and re‑evaluates chaos policies on each execution using the pre‑cleaned query string.
 type WrapperStmt struct {
 	originalStmt driver.Stmt
 	cleanQuery   string

--- a/pkg/sqlchaos/connection_test.go
+++ b/pkg/sqlchaos/connection_test.go
@@ -32,6 +32,7 @@ func (m *MockStmt) Query(args []driver.Value) (driver.Rows, error)  { return nil
 func TestWordBoundaryMatch(t *testing.T) {
 	updateRegex := regexp.MustCompile(`(?i)\bUPDATE\b`)
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:          "sql",
@@ -63,6 +64,7 @@ func TestWordBoundaryMatch(t *testing.T) {
 // TestDoubleChaosPrevention verifies the Fallback Shield (chaosKey)
 func TestDoubleChaosPrevention(t *testing.T) {
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:        "sql",
@@ -93,12 +95,13 @@ func TestDoubleChaosPrevention(t *testing.T) {
 // TestLatencyContextAwareness ensures delays are cancelled when context is done
 func TestLatencyContextAwareness(t *testing.T) {
 	mgr := config.NewManager(&config.PastaayConfig{
+		Version: 1,
 		Policies: []config.Policy{
 			{
 				Type:            "sql",
 				Target:          "all",
 				LatencyChance:   1.0,
-				LatencyDuration: 1 * time.Hour,
+				LatencyDuration: 30 * time.Minute,
 			},
 		},
 	})

--- a/pkg/sqlchaos/driver.go
+++ b/pkg/sqlchaos/driver.go
@@ -68,6 +68,9 @@ func (d *WrapperDriver) Open(name string) (driver.Conn, error) {
 }
 
 func applyConnectionChaos(ctx context.Context, mgr *config.Manager) error {
+	if mgr == nil {
+		return nil
+	}
 	policies := mgr.GetActivePolicies("sql")
 	for _, p := range policies {
 		if !p.DropConnection {
@@ -86,9 +89,8 @@ func applyConnectionChaos(ctx context.Context, mgr *config.Manager) error {
 
 		metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "drop").Inc()
 		_, span := tracing.StartChaosSpan(ctx, "pastaay.sql.drop", p.Target, "drop")
-		// Always end the span on every return path.
-		defer span.End()
 		telemetry.EmitError("sql", p.Target, "Connection force dropped", "TCP stream severed by DropConnection policy", span)
+		span.End()
 		return errors.New("[Pastaay-SQL] Chaos: TCP connection forcefully dropped")
 	}
 	return nil

--- a/pkg/sqlchaos/driver.go
+++ b/pkg/sqlchaos/driver.go
@@ -44,7 +44,7 @@ func (c *fallbackConnector) Connect(ctx context.Context) (driver.Conn, error) {
 }
 func (c *fallbackConnector) Driver() driver.Driver { return c.driver }
 
-// OpenConnector returns a chaos‑aware connector or falls back to a compatibility wrapper if the underlying driver lacks DriverContext.
+// OpenConnector returns a chaos-aware connector or falls back to a compat wrapper.
 func (d *WrapperDriver) OpenConnector(name string) (driver.Connector, error) {
 	if dc, ok := d.original.(driver.DriverContext); ok {
 		connector, err := dc.OpenConnector(name)
@@ -88,9 +88,11 @@ func applyConnectionChaos(ctx context.Context, mgr *config.Manager) error {
 		}
 
 		metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "drop").Inc()
+		// Defer span.End so any panic in telemetry.EmitError still closes the
+		// span and does not leak an active OTLP recording.
 		_, span := tracing.StartChaosSpan(ctx, "pastaay.sql.drop", p.Target, "drop")
+		defer span.End()
 		telemetry.EmitError("sql", p.Target, "Connection force dropped", "TCP stream severed by DropConnection policy", span)
-		span.End()
 		return errors.New("[Pastaay-SQL] Chaos: TCP connection forcefully dropped")
 	}
 	return nil

--- a/pkg/sqlchaos/driver.go
+++ b/pkg/sqlchaos/driver.go
@@ -44,6 +44,7 @@ func (c *fallbackConnector) Connect(ctx context.Context) (driver.Conn, error) {
 }
 func (c *fallbackConnector) Driver() driver.Driver { return c.driver }
 
+// OpenConnector returns a chaos‑aware connector or falls back to a compatibility wrapper if the underlying driver lacks DriverContext.
 func (d *WrapperDriver) OpenConnector(name string) (driver.Connector, error) {
 	if dc, ok := d.original.(driver.DriverContext); ok {
 		connector, err := dc.OpenConnector(name)
@@ -69,19 +70,26 @@ func (d *WrapperDriver) Open(name string) (driver.Conn, error) {
 func applyConnectionChaos(ctx context.Context, mgr *config.Manager) error {
 	policies := mgr.GetActivePolicies("sql")
 	for _, p := range policies {
-		if p.DropConnection && (strings.EqualFold(p.Target, "all") || strings.EqualFold(p.Target, "database")) {
-			chance := p.ErrorChance
-			if chance <= 0 {
-				chance = 1.0
-			}
-			if rand.Float64() < chance {
-				metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "drop").Inc()
-				_, span := tracing.StartChaosSpan(ctx, "pastaay.sql.drop", p.Target, "drop")
-				telemetry.EmitError("sql", p.Target, "Connection force dropped", "TCP stream severed by DropConnection policy", span)
-				span.End()
-				return errors.New("[Pastaay-SQL] Chaos: TCP connection forcefully dropped")
-			}
+		if !p.DropConnection {
+			continue
 		}
+		if !strings.EqualFold(p.Target, "all") && !strings.EqualFold(p.Target, "database") {
+			continue
+		}
+		chance := p.ErrorChance
+		if chance <= 0 {
+			chance = 1.0
+		}
+		if rand.Float64() >= chance {
+			continue
+		}
+
+		metrics.InjectedFaultsTotal.WithLabelValues(p.MetricTag, "drop").Inc()
+		_, span := tracing.StartChaosSpan(ctx, "pastaay.sql.drop", p.Target, "drop")
+		// Always end the span on every return path.
+		defer span.End()
+		telemetry.EmitError("sql", p.Target, "Connection force dropped", "TCP stream severed by DropConnection policy", span)
+		return errors.New("[Pastaay-SQL] Chaos: TCP connection forcefully dropped")
 	}
 	return nil
 }

--- a/pkg/telemetry/bus.go
+++ b/pkg/telemetry/bus.go
@@ -72,13 +72,18 @@ func EmitError(protocol, target, msg, payload string, span trace.Span) {
 }
 
 func EmitInfo(protocol, message string, data map[string]interface{}, span trace.Span) {
-	data["level"] = "INFO"
-	data["protocol"] = protocol
-	data["message"] = message
-	if span != nil && span.SpanContext().IsValid() {
-		data["trace_id"] = span.SpanContext().TraceID().String()
-		data["span_id"] = span.SpanContext().SpanID().String()
+	// Avoid mutating the caller's map.
+	merged := make(map[string]interface{}, len(data)+5)
+	for k, v := range data {
+		merged[k] = v
 	}
-	jsonLog, _ := json.Marshal(data)
+	merged["level"] = "INFO"
+	merged["protocol"] = protocol
+	merged["message"] = message
+	if span != nil && span.SpanContext().IsValid() {
+		merged["trace_id"] = span.SpanContext().TraceID().String()
+		merged["span_id"] = span.SpanContext().SpanID().String()
+	}
+	jsonLog, _ := json.Marshal(merged)
 	Emit(nodeName, protocol, string(jsonLog))
 }

--- a/pkg/telemetry/bus.go
+++ b/pkg/telemetry/bus.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 	"sync"
 	"time"
@@ -67,7 +68,11 @@ func EmitError(protocol, target, msg, payload string, span trace.Span) {
 		logData["trace_id"] = span.SpanContext().TraceID().String()
 		logData["span_id"] = span.SpanContext().SpanID().String()
 	}
-	jsonLog, _ := json.Marshal(logData)
+	jsonLog, err := json.Marshal(logData)
+	if err != nil {
+		log.Printf("[Pastaay-Telemetry] EmitError marshal failed: %v", err)
+		return
+	}
 	Emit(nodeName, protocol, string(jsonLog))
 }
 
@@ -84,6 +89,10 @@ func EmitInfo(protocol, message string, data map[string]interface{}, span trace.
 		merged["trace_id"] = span.SpanContext().TraceID().String()
 		merged["span_id"] = span.SpanContext().SpanID().String()
 	}
-	jsonLog, _ := json.Marshal(merged)
+	jsonLog, err := json.Marshal(merged)
+	if err != nil {
+		log.Printf("[Pastaay-Telemetry] EmitInfo marshal failed: %v", err)
+		return
+	}
 	Emit(nodeName, protocol, string(jsonLog))
 }

--- a/pkg/telemetry/bus_test.go
+++ b/pkg/telemetry/bus_test.go
@@ -1,0 +1,55 @@
+package telemetry
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRingBuffer_WrapsCleanly(t *testing.T) {
+	mu.Lock()
+	buf = [256]LogEntry{}
+	head, size = 0, 0
+	mu.Unlock()
+
+	for i := 0; i < 1000; i++ {
+		Emit("test", "x", "y")
+	}
+	snap := Snapshot()
+	if len(snap) != 256 {
+		t.Fatalf("expected 256 entries after wrap, got %d", len(snap))
+	}
+}
+
+// concurrent Emit + Snapshot must not race.
+func TestRingBuffer_ConcurrentReadWriteSafe(t *testing.T) {
+	mu.Lock()
+	buf = [256]LogEntry{}
+	head, size = 0, 0
+	mu.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				Emit("a", "b", "c")
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = Snapshot()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestEmitError_NilSpanIsSafe(t *testing.T) {
+	EmitError("http", "/x", "msg", "{}", nil)
+	EmitInfo("http", "ok", nil, nil)
+}

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -60,7 +60,7 @@ func InitProvider(ctx context.Context, endpoint string) (func(context.Context) e
 	return tp.Shutdown, nil
 }
 
-// StartChaosSpan creates an OpenTelemetry span tagged with the fault target and type, used by every chaos injection point in the engine.
+// StartChaosSpan creates an OTel span tagged with fault target and type.
 
 func StartChaosSpan(ctx context.Context, operation string, target string, faultType string) (context.Context, trace.Span) {
 	tracer := otel.Tracer(tracerName)

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -56,6 +56,8 @@ func InitProvider(ctx context.Context, endpoint string) (func(context.Context) e
 	return tp.Shutdown, nil
 }
 
+// StartChaosSpan creates an OpenTelemetry span tagged with the fault target and type, used by every chaos injection point in the engine.
+
 func StartChaosSpan(ctx context.Context, operation string, target string, faultType string) (context.Context, trace.Span) {
 	tracer := otel.Tracer(tracerName)
 	ctx, span := tracer.Start(ctx, operation)

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -26,10 +27,13 @@ func InitProvider(ctx context.Context, endpoint string) (func(context.Context) e
 	endpoint = strings.TrimPrefix(endpoint, "https://")
 	endpoint = strings.TrimSuffix(endpoint, "/")
 
-	exp, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithInsecure(),
-	)
+	opts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(endpoint)}
+
+	if os.Getenv("OTEL_EXPORTER_OTLP_INSECURE") == "1" {
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	}
+
+	exp, err := otlptracegrpc.New(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/web/handler.go
+++ b/web/handler.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 const (
 	maxAPIRequestBytes = 1 << 20 // 1 MiB
 	probeTimeout       = 5 * time.Second
+	probeMaxBodyBytes  = 4096
 )
 
 var (
@@ -42,7 +44,25 @@ var (
 	allowedProvs = map[string]bool{"openai": true, "deepseek": true, "gemini": true, "anthropic": true}
 )
 
+// providerKey returns the API key for the given provider from env.
+func providerKey(provider string) string {
+	switch strings.ToLower(provider) {
+	case "openai":
+		return os.Getenv("PASTAAY_OPENAI_KEY")
+	case "deepseek":
+		return os.Getenv("PASTAAY_DEEPSEEK_KEY")
+	case "gemini":
+		return os.Getenv("PASTAAY_GEMINI_KEY")
+	case "anthropic":
+		return os.Getenv("PASTAAY_ANTHROPIC_KEY")
+	}
+	return ""
+}
+
 func emitLocal(name, msg string) { telemetry.Emit("local", name, msg) }
+
+// kubeLogScannerMaxBytes is the max line length for K8s log streams (1 MiB).
+const kubeLogScannerMaxBytes = 1 << 20
 
 func startKubeLogStreamer(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName string) {
 	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Follow: true})
@@ -54,6 +74,7 @@ func startKubeLogStreamer(ctx context.Context, clientset *kubernetes.Clientset, 
 	defer stream.Close()
 
 	scanner := bufio.NewScanner(stream)
+	scanner.Buffer(make([]byte, 0, 64*1024), kubeLogScannerMaxBytes)
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
@@ -61,6 +82,9 @@ func startKubeLogStreamer(ctx context.Context, clientset *kubernetes.Clientset, 
 		default:
 		}
 		telemetry.Emit("kube", podName, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("[Pastaay-K8s] scanner closed for %s: %v", podName, err)
 	}
 }
 
@@ -70,14 +94,19 @@ func watchAndStreamPods(ctx context.Context, clientset *kubernetes.Clientset, na
 	activeStreams := make(map[string]context.CancelFunc)
 	var mu sync.Mutex
 
+	stopAll := func() {
+		mu.Lock()
+		for _, cancel := range activeStreams {
+			cancel()
+		}
+		activeStreams = make(map[string]context.CancelFunc)
+		mu.Unlock()
+	}
+
 	backoff := time.Second
 	for {
 		if ctx.Err() != nil {
-			mu.Lock()
-			for _, cancel := range activeStreams {
-				cancel()
-			}
-			mu.Unlock()
+			stopAll()
 			return
 		}
 
@@ -87,6 +116,7 @@ func watchAndStreamPods(ctx context.Context, clientset *kubernetes.Clientset, na
 			emitLocal("kube-watcher", "watch failed: "+err.Error())
 			select {
 			case <-ctx.Done():
+				stopAll()
 				return
 			case <-time.After(backoff):
 			}
@@ -101,40 +131,65 @@ func watchAndStreamPods(ctx context.Context, clientset *kubernetes.Clientset, na
 		for event := range w.ResultChan() {
 			pod, ok := event.Object.(*corev1.Pod)
 			if !ok {
+				// Call w.Stop outside the mutex to avoid deadlocking client-go.
+				if event.Type == watch.Error {
+					w.Stop()
+				}
 				continue
 			}
-			mu.Lock()
 			switch event.Type {
 			case watch.Added, watch.Modified:
 				if pod.Status.Phase == corev1.PodRunning {
+					mu.Lock()
 					if _, exists := activeStreams[pod.Name]; !exists {
 						streamCtx, cancel := context.WithCancel(ctx)
 						activeStreams[pod.Name] = cancel
 						emitLocal("kube-watcher", "attaching stream to pod "+pod.Name)
 						go startKubeLogStreamer(streamCtx, clientset, namespace, pod.Name)
 					}
+					mu.Unlock()
 				}
 			case watch.Deleted:
+				mu.Lock()
 				if cancel, exists := activeStreams[pod.Name]; exists {
 					cancel()
 					delete(activeStreams, pod.Name)
 					emitLocal("kube-watcher", "detached stream from pod "+pod.Name)
 				}
+				mu.Unlock()
+			case watch.Error:
+				w.Stop()
 			}
-			mu.Unlock()
 		}
+		// When the watch channel closes (network blip, expired RV, etcd
+		// hiccup), we MUST tear down per-pod streams. Otherwise streamers
+		// keep tailing logs against the *old* connection's resource handles
+		// — and any pod that was deleted while the watch was down would
+		// never receive its cancel(). This loop reconnects with a fresh
+		// resource version and rebuilds streams via "Added" events.
+		stopAll()
 		log.Printf("[Pastaay-K8s] watch channel closed, reconnecting")
 		emitLocal("kube-watcher", "watch channel closed, reconnecting")
 	}
 }
 
-// requireConsoleToken enforces auth; in the empty-token mode it logs every
-// request to ensure the security gap is loud.
+// requireConsoleToken enforces auth.
 func requireConsoleToken(expected string, next http.HandlerFunc) http.HandlerFunc {
 	disabled := expected == ""
+	devAllow := os.Getenv("PASTAAY_DEV_ALLOW_NO_TOKEN") == "1"
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Reject browser-driven CSRF
+		if r.Method == http.MethodPost && !isSameOriginOrJSON(r) {
+			http.Error(w, "forbidden (CSRF check failed)", http.StatusForbidden)
+			return
+		}
+
 		if disabled {
-			log.Printf("[Pastaay-Console] SECURITY: unauthenticated %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+			if !devAllow {
+				http.Error(w, "engine token not configured: refusing to serve protected route", http.StatusServiceUnavailable)
+				return
+			}
+			log.Printf("[Pastaay-Console] DEV: unauthenticated %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
 			next(w, r)
 			return
 		}
@@ -147,6 +202,29 @@ func requireConsoleToken(expected string, next http.HandlerFunc) http.HandlerFun
 	}
 }
 
+// isSameOriginOrJSON validates Origin/Referer/Content-Type for form requests.
+func isSameOriginOrJSON(r *http.Request) bool {
+	ct := strings.ToLower(strings.TrimSpace(strings.SplitN(r.Header.Get("Content-Type"), ";", 2)[0]))
+	if ct == "application/json" || ct == "application/yaml" || ct == "application/x-yaml" {
+		return true
+	}
+	host := r.Host
+	if o := r.Header.Get("Origin"); o != "" {
+		if u, err := url.Parse(o); err == nil && strings.EqualFold(u.Host, host) {
+			return true
+		}
+		return false
+	}
+	if rfr := r.Header.Get("Referer"); rfr != "" {
+		if u, err := url.Parse(rfr); err == nil && strings.EqualFold(u.Host, host) {
+			return true
+		}
+		return false
+	}
+	// No Origin/Referer
+	return false
+}
+
 func renderHTML(tmpl *template.Template, w http.ResponseWriter, page string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := tmpl.ExecuteTemplate(w, "layout.html", map[string]string{"Page": page}); err != nil {
@@ -154,15 +232,14 @@ func renderHTML(tmpl *template.Template, w http.ResponseWriter, page string) {
 	}
 }
 
-// handleOracle delegates to the configured LLM provider, validates the modeln// name against a regex allow‑list, and returns the generated YAML blueprint.
-
+// handleOracle proxies AI requests using server-side keys.
 func handleOracle(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	var req struct {
-		Provider, Key, Model, Intensity, Prompt, Context string
+		Provider, Model, Intensity, Prompt, Context string
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, maxAPIRequestBytes)).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -170,7 +247,7 @@ func handleOracle(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	if !allowedProvs[req.Provider] {
+	if !allowedProvs[strings.ToLower(req.Provider)] {
 		http.Error(w, "unsupported provider", http.StatusBadRequest)
 		return
 	}
@@ -179,8 +256,14 @@ func handleOracle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	apiKey := providerKey(req.Provider)
+	if apiKey == "" {
+		http.Error(w, "provider not configured on engine", http.StatusServiceUnavailable)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	resp, err := oracle.AskOracle(req.Provider, req.Key, req.Model, req.Intensity, req.Prompt, req.Context)
+	resp, err := oracle.AskOracleCtx(r.Context(), req.Provider, apiKey, req.Model, req.Intensity, req.Prompt, req.Context)
 	if err != nil {
 		w.WriteHeader(http.StatusBadGateway)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
@@ -231,7 +314,7 @@ func handleState(mgr *config.Manager) http.HandlerFunc {
 		}
 
 		activePolicies := 0
-		var policies []config.Policy = []config.Policy{}
+		var policies = []config.Policy{}
 
 		if cfg != nil {
 			activePolicies = len(cfg.Policies)
@@ -294,37 +377,6 @@ func handleMetrics(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(metricsList)
 }
 
-// safeProbeTransport rejects connections to private / loopback / link-local /
-// multicast / unspecified ranges and refuses any redirect.
-var safeProbeTransport = &http.Transport{
-	DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-		host, _, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, err
-		}
-		ips, err := (&net.Resolver{}).LookupIPAddr(ctx, host)
-		if err != nil {
-			return nil, err
-		}
-		for _, ip := range ips {
-			if isInternalIP(ip.IP) {
-				return nil, fmt.Errorf("pastaay: refused to dial internal address %s", ip.IP)
-			}
-		}
-		d := &net.Dialer{Timeout: 3 * time.Second}
-		return d.DialContext(ctx, network, addr)
-	},
-	ResponseHeaderTimeout: probeTimeout,
-}
-
-var safeProbeClient = &http.Client{
-	Transport: safeProbeTransport,
-	Timeout:   probeTimeout,
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return errors.New("pastaay: redirects are disabled for probe targets")
-	},
-}
-
 func isInternalIP(ip net.IP) bool {
 	if ip == nil {
 		return true
@@ -333,8 +385,6 @@ func isInternalIP(ip net.IP) bool {
 		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
 		return true
 	}
-	// IPv4: AWS/GCP/Azure metadata (169.254.169.254 caught by IsLinkLocal),
-	// shared address space (100.64.0.0/10).
 	if v4 := ip.To4(); v4 != nil {
 		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
 			return true
@@ -343,7 +393,26 @@ func isInternalIP(ip net.IP) bool {
 	return false
 }
 
-// handleProbe performs an HTTP GET against a user‑supplied URL through an// hardened transport that refuses connections to internal/loopback addresses.
+// safeProbeClient is a per-request constructor
+func newSafeProbeClient(ip net.IP, port string) *http.Client {
+	pinned := net.JoinHostPort(ip.String(), port)
+	dialer := &net.Dialer{Timeout: 3 * time.Second}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			// Ignore the caller-supplied addr and dial the pinned IP instead.
+			return dialer.DialContext(ctx, network, pinned)
+		},
+		ResponseHeaderTimeout: probeTimeout,
+		DisableKeepAlives:     true,
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   probeTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errors.New("pastaay: redirects are disabled for probe targets")
+		},
+	}
+}
 
 func handleProbe(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -370,11 +439,43 @@ func handleProbe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
 	result := map[string]interface{}{}
 	w.Header().Set("Content-Type", "application/json")
 
 	ctx, cancel := context.WithTimeout(r.Context(), probeTimeout)
 	defer cancel()
+
+	// Single resolution pass — pick the first public IP.
+	ips, lerr := (&net.Resolver{}).LookupIPAddr(ctx, host)
+	if lerr != nil || len(ips) == 0 {
+		result["status"] = 0
+		result["error"] = fmt.Sprintf("dns resolve: %v", lerr)
+		_ = json.NewEncoder(w).Encode(result)
+		return
+	}
+	var pinned net.IP
+	for _, ip := range ips {
+		if !isInternalIP(ip.IP) {
+			pinned = ip.IP
+			break
+		}
+	}
+	if pinned == nil {
+		result["status"] = 0
+		result["error"] = "pastaay: refused to dial only-internal hostname"
+		_ = json.NewEncoder(w).Encode(result)
+		return
+	}
 
 	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL, nil)
 	if err != nil {
@@ -384,8 +485,11 @@ func handleProbe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	client := newSafeProbeClient(pinned, port)
+	defer client.CloseIdleConnections()
+
 	start := time.Now()
-	resp, err := safeProbeClient.Do(probeReq)
+	resp, err := client.Do(probeReq)
 	elapsed := time.Since(start).Milliseconds()
 	result["elapsed_ms"] = elapsed
 
@@ -396,8 +500,7 @@ func handleProbe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
-	// Drain at most 4 KiB so we never load attacker bodies.
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, probeMaxBodyBytes))
 
 	result["status"] = resp.StatusCode
 	result["error"] = nil
@@ -431,13 +534,14 @@ func handleDiscover(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(targetList)
 }
 
-func RegisterHandlers(mux *http.ServeMux, mgr *config.Manager) {
+// RegisterHandlers wires console + admin API routes onto mux.
+func RegisterHandlers(ctx context.Context, mux *http.ServeMux, mgr *config.Manager) {
 	adminToken := os.Getenv("PASTAAY_WEBHOOK_TOKEN")
 
 	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
 		if restConfig, err := rest.InClusterConfig(); err == nil {
 			if clientset, csErr := kubernetes.NewForConfig(restConfig); csErr == nil {
-				go watchAndStreamPods(context.Background(), clientset, getEnv("PASTAAY_K8S_NAMESPACE", "default"))
+				go watchAndStreamPods(ctx, clientset, getEnv("PASTAAY_K8S_NAMESPACE", "default"))
 			}
 		}
 	}
@@ -450,7 +554,7 @@ func RegisterHandlers(mux *http.ServeMux, mgr *config.Manager) {
 	mux.HandleFunc("/console/docs", func(w http.ResponseWriter, r *http.Request) { renderHTML(tmpl, w, "docs") })
 	mux.HandleFunc("/console/builder", func(w http.ResponseWriter, r *http.Request) { renderHTML(tmpl, w, "builder") })
 
-	mux.HandleFunc("/console/api/metrics", handleMetrics)
+	mux.HandleFunc("/console/api/metrics", requireConsoleToken(adminToken, handleMetrics))
 	mux.HandleFunc("/console/api/state", requireConsoleToken(adminToken, handleState(mgr)))
 	mux.HandleFunc("/console/api/probe", requireConsoleToken(adminToken, handleProbe))
 	mux.HandleFunc("/console/api/discover", requireConsoleToken(adminToken, handleDiscover))

--- a/web/handler.go
+++ b/web/handler.go
@@ -5,10 +5,16 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"html/template"
+	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 
@@ -24,6 +30,16 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+)
+
+const (
+	maxAPIRequestBytes = 1 << 20 // 1 MiB
+	probeTimeout       = 5 * time.Second
+)
+
+var (
+	modelNameRe  = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+	allowedProvs = map[string]bool{"openai": true, "deepseek": true, "gemini": true, "anthropic": true}
 )
 
 func emitLocal(name, msg string) { telemetry.Emit("local", name, msg) }
@@ -48,11 +64,8 @@ func startKubeLogStreamer(ctx context.Context, clientset *kubernetes.Clientset, 
 	}
 }
 
-func EmitLog(source, name, msg string) {
-	telemetry.Emit(source, name, msg)
-}
+func EmitLog(source, name, msg string) { telemetry.Emit(source, name, msg) }
 
-// watchAndStreamPods uses K8s Watch API
 func watchAndStreamPods(ctx context.Context, clientset *kubernetes.Clientset, namespace string) {
 	activeStreams := make(map[string]context.CancelFunc)
 	var mu sync.Mutex
@@ -115,10 +128,13 @@ func watchAndStreamPods(ctx context.Context, clientset *kubernetes.Clientset, na
 	}
 }
 
-// Auth middleware
+// requireConsoleToken enforces auth; in the empty-token mode it logs every
+// request to ensure the security gap is loud.
 func requireConsoleToken(expected string, next http.HandlerFunc) http.HandlerFunc {
+	disabled := expected == ""
 	return func(w http.ResponseWriter, r *http.Request) {
-		if expected == "" {
+		if disabled {
+			log.Printf("[Pastaay-Console] SECURITY: unauthenticated %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
 			next(w, r)
 			return
 		}
@@ -138,7 +154,7 @@ func renderHTML(tmpl *template.Template, w http.ResponseWriter, page string) {
 	}
 }
 
-// Handlers
+// handleOracle delegates to the configured LLM provider, validates the modeln// name against a regex allow‑list, and returns the generated YAML blueprint.
 
 func handleOracle(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -148,20 +164,29 @@ func handleOracle(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Provider, Key, Model, Intensity, Prompt, Context string
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxAPIRequestBytes)).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
 		return
 	}
 	defer r.Body.Close()
 
+	if !allowedProvs[req.Provider] {
+		http.Error(w, "unsupported provider", http.StatusBadRequest)
+		return
+	}
+	if req.Model != "" && !modelNameRe.MatchString(req.Model) {
+		http.Error(w, "invalid model name", http.StatusBadRequest)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	resp, err := oracle.AskOracle(req.Provider, req.Key, req.Model, req.Intensity, req.Prompt, req.Context)
 	if err != nil {
 		w.WriteHeader(http.StatusBadGateway)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	json.NewEncoder(w).Encode(map[string]string{"response": resp, "yaml": oracle.ExtractYAML(resp)})
+	_ = json.NewEncoder(w).Encode(map[string]string{"response": resp, "yaml": oracle.ExtractYAML(resp)})
 }
 
 func handlePlan(w http.ResponseWriter, r *http.Request) {
@@ -170,19 +195,25 @@ func handlePlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
-	var cfg config.PastaayConfig
-	if err := yaml.NewDecoder(r.Body).Decode(&cfg); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+
+	result, err := guard.PlanFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	json.NewEncoder(w).Encode(guard.Analyze(&cfg))
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func handleRollback(mgr *config.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		mgr.Update(&config.PastaayConfig{Version: 1, Policies: []config.Policy{}})
 		emitLocal("pastaay", "rollback executed — all policies cleared")
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}
 }
 
@@ -225,7 +256,7 @@ func handleState(mgr *config.Manager) http.HandlerFunc {
 			"engine_logs":     telemetry.Snapshot(),
 		}
 
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}
 }
 
@@ -260,8 +291,59 @@ func handleMetrics(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	json.NewEncoder(w).Encode(metricsList)
+	_ = json.NewEncoder(w).Encode(metricsList)
 }
+
+// safeProbeTransport rejects connections to private / loopback / link-local /
+// multicast / unspecified ranges and refuses any redirect.
+var safeProbeTransport = &http.Transport{
+	DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := (&net.Resolver{}).LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		for _, ip := range ips {
+			if isInternalIP(ip.IP) {
+				return nil, fmt.Errorf("pastaay: refused to dial internal address %s", ip.IP)
+			}
+		}
+		d := &net.Dialer{Timeout: 3 * time.Second}
+		return d.DialContext(ctx, network, addr)
+	},
+	ResponseHeaderTimeout: probeTimeout,
+}
+
+var safeProbeClient = &http.Client{
+	Transport: safeProbeTransport,
+	Timeout:   probeTimeout,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return errors.New("pastaay: redirects are disabled for probe targets")
+	},
+}
+
+func isInternalIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	// IPv4: AWS/GCP/Azure metadata (169.254.169.254 caught by IsLinkLocal),
+	// shared address space (100.64.0.0/10).
+	if v4 := ip.To4(); v4 != nil {
+		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return true
+		}
+	}
+	return false
+}
+
+// handleProbe performs an HTTP GET against a user‑supplied URL through an// hardened transport that refuses connections to internal/loopback addresses.
 
 func handleProbe(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -271,7 +353,7 @@ func handleProbe(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		URL string `json:"url"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxAPIRequestBytes)).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
 		return
 	}
@@ -282,29 +364,44 @@ func handleProbe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	start := time.Now()
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(req.URL)
-	elapsed := time.Since(start).Milliseconds()
-
-	result := map[string]interface{}{
-		"elapsed_ms": elapsed,
+	u, err := url.Parse(req.URL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		http.Error(w, "url must be http(s) with explicit host", http.StatusBadRequest)
+		return
 	}
+
+	result := map[string]interface{}{}
+	w.Header().Set("Content-Type", "application/json")
+
+	ctx, cancel := context.WithTimeout(r.Context(), probeTimeout)
+	defer cancel()
+
+	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL, nil)
+	if err != nil {
+		result["status"] = 0
+		result["error"] = err.Error()
+		_ = json.NewEncoder(w).Encode(result)
+		return
+	}
+
+	start := time.Now()
+	resp, err := safeProbeClient.Do(probeReq)
+	elapsed := time.Since(start).Milliseconds()
+	result["elapsed_ms"] = elapsed
 
 	if err != nil {
 		result["status"] = 0
 		result["error"] = err.Error()
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(result)
+		_ = json.NewEncoder(w).Encode(result)
 		return
 	}
 	defer resp.Body.Close()
+	// Drain at most 4 KiB so we never load attacker bodies.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 
 	result["status"] = resp.StatusCode
 	result["error"] = nil
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func handleDiscover(w http.ResponseWriter, r *http.Request) {
@@ -331,13 +428,12 @@ func handleDiscover(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	json.NewEncoder(w).Encode(targetList)
+	_ = json.NewEncoder(w).Encode(targetList)
 }
 
 func RegisterHandlers(mux *http.ServeMux, mgr *config.Manager) {
 	adminToken := os.Getenv("PASTAAY_WEBHOOK_TOKEN")
 
-	// K8s watcher
 	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
 		if restConfig, err := rest.InClusterConfig(); err == nil {
 			if clientset, csErr := kubernetes.NewForConfig(restConfig); csErr == nil {

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -1,0 +1,224 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/CemAkan/pastaay/pkg/config"
+)
+
+func TestRequireConsoleToken_FailClosed(t *testing.T) {
+	t.Setenv("PASTAAY_DEV_ALLOW_NO_TOKEN", "")
+	called := false
+	h := requireConsoleToken("", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 fail-closed, got %d", rr.Code)
+	}
+	if called {
+		t.Fatal("handler must not run when token is unconfigured")
+	}
+}
+
+func TestRequireConsoleToken_DevAllowNoToken(t *testing.T) {
+	t.Setenv("PASTAAY_DEV_ALLOW_NO_TOKEN", "1")
+	called := false
+	h := requireConsoleToken("", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if rr.Code != http.StatusOK || !called {
+		t.Fatalf("dev override must allow access; code=%d called=%v", rr.Code, called)
+	}
+}
+
+func TestRequireConsoleToken_ConstantTimeReject(t *testing.T) {
+	h := requireConsoleToken("expected-secret", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("X-Pastaay-Token", "wrong")
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestRequireConsoleToken_CSRF_PostFormDenied(t *testing.T) {
+	h := requireConsoleToken("token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("a=1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Pastaay-Token", "token")
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.Host = "console.example.com"
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 CSRF, got %d", rr.Code)
+	}
+}
+
+func TestRequireConsoleToken_CSRF_PostJSONAllowed(t *testing.T) {
+	h := requireConsoleToken("token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{"a":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Pastaay-Token", "token")
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("application/json POST must pass CSRF gate, got %d", rr.Code)
+	}
+}
+
+func TestHandleProbe_RejectsInternalLiteral(t *testing.T) {
+	body := strings.NewReader(`{"url":"http://127.0.0.1/admin"}`)
+	req := httptest.NewRequest(http.MethodPost, "/probe", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handleProbe(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("probe handler should return JSON even on refusal, got code %d", rr.Code)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("response not valid JSON: %v", err)
+	}
+	errStr, _ := out["error"].(string)
+	if !strings.Contains(errStr, "internal") && !strings.Contains(errStr, "refused") {
+		t.Fatalf("expected internal-IP refusal, got %v", out)
+	}
+}
+
+func TestHandleProbe_RejectsRFC1918(t *testing.T) {
+	body := strings.NewReader(`{"url":"http://10.0.0.5/x"}`)
+	req := httptest.NewRequest(http.MethodPost, "/probe", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handleProbe(rr, req)
+	var out map[string]interface{}
+	_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	if errStr, _ := out["error"].(string); !strings.Contains(errStr, "internal") {
+		t.Fatalf("expected internal refusal, got %v", out)
+	}
+}
+
+func TestHandleProbe_RejectsLinkLocal(t *testing.T) {
+	body := strings.NewReader(`{"url":"http://169.254.169.254/latest/meta-data/"}`)
+	req := httptest.NewRequest(http.MethodPost, "/probe", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handleProbe(rr, req)
+	if !strings.Contains(rr.Body.String(), "internal") {
+		t.Fatalf("EC2 metadata service IP must be rejected (got %s)", rr.Body.String())
+	}
+}
+
+func TestHandleProbe_RejectsBadSchemes(t *testing.T) {
+	for _, url := range []string{
+		"file:///etc/passwd",
+		"gopher://internal/x",
+		"ftp://example.com",
+		"",
+	} {
+		body := strings.NewReader(`{"url":"` + url + `"}`)
+		req := httptest.NewRequest(http.MethodPost, "/probe", body)
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		handleProbe(rr, req)
+		if rr.Code != http.StatusBadRequest && !strings.Contains(rr.Body.String(), "error") && url != "" {
+			t.Errorf("scheme %q should be rejected, body=%s", url, rr.Body.String())
+		}
+	}
+}
+
+func TestIsInternalIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"169.254.169.254", true},
+		{"100.64.0.1", true}, // CGNAT
+		{"100.127.255.254", true},
+		{"100.128.0.1", false}, // outside CGNAT
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"::1", true},
+		{"fe80::1", true},
+		{"ff00::1", true},
+		{"2001:4860:4860::8888", false}, // Google DNS v6
+	}
+	for _, c := range cases {
+		ip := net.ParseIP(c.ip)
+		if got := isInternalIP(ip); got != c.want {
+			t.Errorf("isInternalIP(%s) = %v want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+func TestHandleOracle_ServerSideKeyOnly(t *testing.T) {
+	_ = os.Unsetenv("PASTAAY_OPENAI_KEY")
+	body := strings.NewReader(`{"provider":"openai","prompt":"x","intensity":"low"}`)
+	req := httptest.NewRequest(http.MethodPost, "/oracle", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handleOracle(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when provider not configured, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleOracle_RejectsBadProvider(t *testing.T) {
+	body := strings.NewReader(`{"provider":"hacker","prompt":"x"}`)
+	req := httptest.NewRequest(http.MethodPost, "/oracle", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handleOracle(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported provider, got %d", rr.Code)
+	}
+}
+
+func TestHandleOracle_RejectsHugeBody(t *testing.T) {
+	big := strings.Repeat("a", maxAPIRequestBytes+1024)
+	body := strings.NewReader(`{"provider":"openai","prompt":"` + big + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/oracle", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handleOracle(rr, req)
+	// decoder errors with 400.
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on oversized body, got %d", rr.Code)
+	}
+}
+
+func TestRegisterHandlers_RespectsCancelledContext(t *testing.T) {
+	mgr := config.NewManager(&config.PastaayConfig{Version: 1})
+	mux := http.NewServeMux()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	RegisterHandlers(ctx, mux, mgr) // must not panic and block
+}


### PR DESCRIPTION

   - Config: field caps, watcher race fix, webhook size guard
   - Interceptors: tie-break on broker, gRPC, redis, mongo
   - MongoDB: client wrapper for real command abortion
   - CLI: explicit redis addr, api-key guard, signal handling
   - Resource: FNV hashing instead of XOR
   - Chore: test consolidation
